### PR TITLE
Update flydotio.md

### DIFF
--- a/pages/deployment/flydotio.md
+++ b/pages/deployment/flydotio.md
@@ -62,7 +62,7 @@ Choose `Development` configuration to use free instance of Postgres.
 To connecting the Postgres database with the app, we need to attach by using this command:
 
 ```sh
-flyctl postgres attach --postgres-app <POSTGRES_APP_NAME>
+flyctl postgres attach <POSTGRES_APP_NAME>
 ```
 
 ### Step 4: Setup Redis instance


### PR DESCRIPTION
On v0.0.502 of `flyctl.  the help docs indicate that the flag is not necessary and raises an error when used

```
Error: unknown flag: --postgres-app
Usage:
  flyctl postgres attach <POSTGRES APP> [flags]
```