### PR TITLE
Fix typo in SMTP config page

### DIFF
--- a/pages/core/email.mdx
+++ b/pages/core/email.mdx
@@ -23,4 +23,4 @@ SMTP_USERNAME: apikey
 SENDER_EMAIL: <Sendgrid verified email>
 ```
 
-> Note: the `SMTP_USERNAME` environment variable must be set to the liternal string `apikey` **not** your API key value.
+> Note: the `SMTP_USERNAME` environment variable must be set to the literal string `apikey` **not** your API key value.


### PR DESCRIPTION
Hello,

I implemented a micro-fix in the page for configuring Sendgrid as the SMTP server. 

# Change
- `liternal` to `literal`