### PR TITLE
docs(core): document AuthorizerAdminService + split Public/Admin API TOC

### DIFF
--- a/docs/core/authorization.md
+++ b/docs/core/authorization.md
@@ -271,7 +271,7 @@ mutation {
 ```
 
 Full parameter tables and examples for every operation live in the
-[GraphQL API reference](./graphql-api#authorization-admin).
+[GraphQL API reference](./graphql-api#authorization-fga).
 
 ---
 

--- a/docs/core/graphql-api.md
+++ b/docs/core/graphql-api.md
@@ -858,7 +858,7 @@ mutation {
 
 ## Authorizer Admin APIs
 
-All admin operations require super-admin authentication via either the `x-authorizer-admin-secret` header or the `authorizer.admin` HTTP-only session cookie (set by `_admin_login`). Except `_admin_login`, which may be called without an existing session. Admin operations are not exposed over REST or gRPC in the current release.
+All admin operations require super-admin authentication via either the `x-authorizer-admin-secret` header or the `authorizer.admin` HTTP-only session cookie (set by `_admin_login`). Except `_admin_login`, which may be called without an existing session. The same operations are also available over gRPC and REST through the `AuthorizerAdminService` (see the [gRPC](./grpc.md) and [REST](./rest-api.md) references).
 
 ### Admin Authentication
 

--- a/docs/core/graphql-api.md
+++ b/docs/core/graphql-api.md
@@ -13,57 +13,63 @@ You can play with GraphQL API using the GraphQL playground that comes with your 
 
 Table of Contents
 
-- [GraphQL API](#queries)
-  - [Queries](#queries)
-    - [`meta`](#meta)
-    - [`session`](#session)
-    - [`profile`](#profile)
-    - [`validate_jwt_token`](#validate_jwt_token)
-    - [`validate_session`](#validate_session)
-    - [`check_permissions`](#check_permissions)
-    - [`list_permissions`](#list_permissions)
-    - [`_users`](#_users)
-    - [`_user`](#_user)
-    - [`_verification_requests`](#_verification_requests)
-    - [`_admin_session`](#_admin_session)
-    - [`_env`](#_env)
-    - [`_webhook`](#_webhook)
-    - [`_webhooks`](#_webhooks)
-    - [`_webhook_logs`](#_webhook_logs)
-    - [`_email_templates`](#_email_templates)
-  - [Mutations](#mutations)
-    - [`signup`](#signup)
-    - [`login`](#login)
-    - [`magic_link_login`](#magic_link_login)
-    - [`logout`](#logout)
-    - [`update_profile`](#update_profile)
-    - [`verify_email`](#verify_email)
-    - [`resend_verify_email`](#resend_verify_email)
-    - [`forgot_password`](#forgot_password)
-    - [`reset_password`](#reset_password)
-    - [`revoke`](#revoke)
-    - [`verify_otp`](#verify_otp)
-    - [`resend_otp`](#resend_otp)
-    - [`verify_totp`](#verify_totp)
-    - [`deactivate_account`](#deactivate_account)
-    - [`_admin_signup`](#_admin_signup)
-    - [`_admin_login`](#_admin_login)
-    - [`_admin_logout`](#_admin_logout)
-    - [`_update_env`](#_update_env)
-    - [`_update_user`](#_update_user)
-    - [`_delete_user`](#_delete_user)
-    - [`_invite_members`](#_invite_members)
-    - [`_revoke_access`](#_revoke_access)
-    - [`_enable_access`](#_enable_access)
-    - [`_generate_jwt_keys`](#_generate_jwt_keys)
-    - [`_test_endpoint`](#_test_endpoint)
-    - [`_add_webhook`](#_add_webhook)
-    - [`_update_webhook`](#_update_webhook)
-    - [`_delete_webhook`](#_delete_webhook)
-    - [`_add_email_template`](#_add_email_template)
-    - [`_update_email_template`](#_update_email_template)
-    - [`_delete_email_template`](#_delete_email_template)
-    - [Authorization (admin)](#authorization-admin)
+- [GraphQL API](./graphql-api)
+  - [Public APIs](#public-apis)
+    - [Queries](#queries)
+      - [`meta`](#meta)
+      - [`session`](#session)
+      - [`profile`](#profile)
+      - [`validate_jwt_token`](#validate_jwt_token)
+      - [`validate_session`](#validate_session)
+      - [`check_permissions`](#check_permissions)
+      - [`list_permissions`](#list_permissions)
+    - [Mutations](#mutations)
+      - [`signup`](#signup)
+      - [`login`](#login)
+      - [`magic_link_login`](#magic_link_login)
+      - [`logout`](#logout)
+      - [`update_profile`](#update_profile)
+      - [`verify_email`](#verify_email)
+      - [`resend_verify_email`](#resend_verify_email)
+      - [`forgot_password`](#forgot_password)
+      - [`reset_password`](#reset_password)
+      - [`revoke`](#revoke)
+      - [`verify_otp`](#verify_otp)
+      - [`resend_otp`](#resend_otp)
+      - [`verify_totp`](#verify_totp)
+      - [`deactivate_account`](#deactivate_account)
+  - [Authorizer Admin APIs](#authorizer-admin-apis)
+    - [Admin Authentication](#admin-authentication)
+      - [`_admin_login`](#_admin_login)
+      - [`_admin_logout`](#_admin_logout)
+      - [`_admin_session`](#_admin_session)
+      - [`_admin_meta`](#_admin_meta)
+    - [Users](#users)
+      - [`_users`](#_users)
+      - [`_user`](#_user)
+      - [`_update_user`](#_update_user)
+      - [`_delete_user`](#_delete_user)
+      - [`_verification_requests`](#_verification_requests)
+    - [Access Control](#access-control)
+      - [`_revoke_access`](#_revoke_access)
+      - [`_enable_access`](#_enable_access)
+      - [`_invite_members`](#_invite_members)
+    - [Webhooks](#webhooks)
+      - [`_add_webhook`](#_add_webhook)
+      - [`_update_webhook`](#_update_webhook)
+      - [`_delete_webhook`](#_delete_webhook)
+      - [`_webhook`](#_webhook)
+      - [`_webhooks`](#_webhooks)
+      - [`_webhook_logs`](#_webhook_logs)
+      - [`_test_endpoint`](#_test_endpoint)
+    - [Email Templates](#email-templates)
+      - [`_add_email_template`](#_add_email_template)
+      - [`_update_email_template`](#_update_email_template)
+      - [`_delete_email_template`](#_delete_email_template)
+      - [`_email_templates`](#_email_templates)
+    - [Audit Logs](#audit-logs)
+      - [`_audit_logs`](#_audit_logs)
+    - [Authorization (FGA)](#authorization-fga)
       - [`_fga_write_model`](#_fga_write_model)
       - [`_fga_get_model`](#_fga_get_model)
       - [`_fga_write_tuples`](#_fga_write_tuples)
@@ -73,7 +79,9 @@ Table of Contents
       - [`_fga_expand`](#_fga_expand)
       - [`_fga_reset`](#_fga_reset)
 
-## Queries
+## Public APIs
+
+### Queries
 
 ### `meta`
 
@@ -351,356 +359,8 @@ query {
 
 `FgaTupleInput` (used by `contextual_tuples` above and by the admin operations) is `{ user: String!, relation: String!, object: String! }`.
 
-### `_user`
 
-Query to get a specific user by either id or email.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer.admin` as http only cookie.
-
-```json
-{
-  "x-authorizer-admin-secret": "ADMIN_SECRET"
-}
-```
-
-It requires either of following parameters
-
-**Request Param**
-
-| Key     | Description            | Required |
-| ------- | ---------------------- | -------- |
-| `id`    | Identifier of the user | false    |
-| `email` | User's email address   | false    |
-
-**Sample Query**
-
-```graphql
-query {
-  _user(params: {
-    id: '123-123123-1231231'
-  }) {
-    id
-    email
-  }
-}
-```
-
-It returns the whole `User` object mentioned in [profile](#profile) query section
-
-### `_users`
-
-Query to get all the `_users`. This query is only allowed for super admins. It returns array of users `Users` with below mentioned keys.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer.admin` as http only cookie.
-
-```json
-{
-  "x-authorizer-admin-secret": "ADMIN_SECRET"
-}
-```
-
-It can take optional `params` input of type `PaginatedInput` with following keys
-
-**Request Params**
-
-| Key     | Description                  | Required | Default |
-| ------- | ---------------------------- | -------- | ------- |
-| `page`  | Number of page that you want | false    | 1       |
-| `limit` | Number of rows that you want | false    | 10      |
-
-**Sample Query**
-
-```graphql
-query {
-  _users(params: {
-    pagination: {
-      page: 2
-      limit: 10
-    }
-  }) {
-    pagination: {
-      offset
-      total
-      page
-      limit
-    }
-    users {
-      id
-      given_name
-      family_name
-      email
-      picture
-      roles
-    }
-  }
-}
-```
-
-### `_verification_requests`
-
-Query to get all the `_verification_requests`. This query is only allowed for super admins. It returns array of verification requests `[VerificationRequest!]!` with following keys.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-```json
-{
-  "x-authorizer-admin-secret": "ADMIN_SECRET"
-}
-```
-
-It can take optional `params` input of type `PaginatedInput` with following keys
-
-**Request Params**
-
-| Key     | Description                  | Required | Default |
-| ------- | ---------------------------- | -------- | ------- |
-| `page`  | Number of page that you want | false    | 1       |
-| `limit` | Number of rows that you want | false    | 10      |
-
-**Sample Query**
-
-```graphql
-query {
-  _verification_requests(params: { pagination: { limit: 10, page: 2 } }) {
-    pagination {
-      limit
-      offset
-      page
-    }
-    verification_requests {
-      id
-      token
-      email
-      expires
-      identifier
-    }
-  }
-}
-```
-
-### `_admin_session`
-
-Query to get admin session for dashboard
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-```json
-{
-  "x-authorizer-admin-secret": "ADMIN_SECRET"
-}
-```
-
-| Key       | Description                          |
-| --------- | ------------------------------------ |
-| `message` | Success response message from server |
-
-**Sample Query**
-
-```graphql
-query {
-  _admin_session {
-    message
-  }
-}
-```
-
-### `_env`
-
-Query to get all the environment variables.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-```json
-{
-  "x-authorizer-admin-secret": "ADMIN_SECRET"
-}
-```
-
-All the environment variable values can be obtained using this query.
-
-**Sample Query**
-
-```graphql
-query {
-  _env {
-    DATABASE_TYPE
-    DATABASE_URL
-    DATABASE_NAME
-    CLIENT_ID
-   CLIENT_SECRET
-    ...
-  }
-}
-```
-
-### `_webhook`
-
-Query to get webhook by its identifier. This query is allowed for admins only. It accepts `params` of type `WebhookRequest` with following keys and returns `Webhook`
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-**Request Params**
-
-| Key  | Description               | Required |
-| ---- | ------------------------- | -------- |
-| `id` | Identifier of the webhook | `true`   |
-
-**Response**
-
-| Key          | Description                                                                |
-| ------------ | -------------------------------------------------------------------------- |
-| `id`         | Identifier of the webhook                                                  |
-| `event_name` | Event for which the webhook will be executed                               |
-| `endpoint`   | Endpoint that is to be called                                              |
-| `enabled`    | Boolean to know if webhook is enabled or disabled                          |
-| `headers`    | JSON key, value pair object with the set of headers to be sent for webhook |
-| `created_at` | Time at which the webhook entry was created                                |
-| `updated_at` | Time at which the webhook entry was updated                                |
-
-**Sample Query**
-
-```graphql
-query {
-  _webhook(params: { id: "123-adfa-123412-asdfasda" }) {
-    id
-    event_name
-  }
-}
-```
-
-### `_webhooks`
-
-Query to get list of webhooks. This query is allowed for admins only.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-It can take optional `params` input of type `PaginatedInput` with following keys
-
-**Request Params**
-
-| Key     | Description                  | Required | Default |
-| ------- | ---------------------------- | -------- | ------- |
-| `page`  | Number of page that you want | false    | 1       |
-| `limit` | Number of rows that you want | false    | 10      |
-
-**Response**
-
-It returns response of type `Webhooks` with following keys
-
-| Key        | Description                                             |
-| ---------- | ------------------------------------------------------- |
-| pagination | object with `limit`, `page`, `offset` & `total` value   |
-| webhooks   | List of webhook with params mentioned [here](#_webhook) |
-
-**Sample Query**
-
-```graphql
-_webhooks(params: {limit: 10, page: 1}) {
-  pagination {
-    limit
-    offset
-    total
-  }
-  webhooks {
-    id
-    event_name
-    endpoint
-  }
-}
-```
-
-### `_webhook_logs`
-
-Query to get list of webhook logs. This query is allowed for admins only.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-It can take optional `params` input of type `ListWebhookLogRequest` with following keys
-
-**Request Params**
-
-| Key          | Description                         | Required | Default                |
-| ------------ | ----------------------------------- | -------- | ---------------------- |
-| `pagination` | Pagination object with limit & page | false    | `{limit: 10, page: 1}` |
-| `webhook_id` | Identifier for the webhook          | false    | null                   |
-
-**Response**
-
-It returns response of type `WebhookLogs` with following keys
-
-| Key          | Description                                                                                                |
-| ------------ | ---------------------------------------------------------------------------------------------------------- |
-| pagination   | object with `limit`, `page`, `offset` & `total` value                                                      |
-| webhook_logs | List of webhook log (`id`, `http_status`, `request`, `response`, `webhook_id`, `created_at`, `updated_at`) |
-
-**Sample Query**
-
-```graphql
-_webhook_logs(params: {
-  pagination: {
-    limit: 10
-  }
-  webhook_id: "test"
-}) {
-  pagination {
-    limit
-    offset
-    total
-  }
-  webhook_logs {
-    id
-    http_status
-    request
-    response
-    webhook_id
-  }
-}
-```
-
-### `_email_templates`
-
-Query to get list of email templates. This query is allowed for admins only.
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-It can take optional `params` input of type `PaginatedInput` with following keys
-
-**Request Params**
-
-| Key     | Description                  | Required | Default |
-| ------- | ---------------------------- | -------- | ------- |
-| `page`  | Number of page that you want | false    | 1       |
-| `limit` | Number of rows that you want | false    | 10      |
-
-**Response**
-
-It returns response of type `EmailTemplates` with following keys
-
-| Key             | Description                                           |
-| --------------- | ----------------------------------------------------- |
-| pagination      | object with `limit`, `page`, `offset` & `total` value |
-| email_templates | List of email template                                |
-
-**Sample Query**
-
-```graphql
-_email_templates(params: {limit: 10, page: 1}) {
-  pagination {
-    limit
-    offset
-    total
-  }
-  webhooks {
-    id
-    template
-    event_name
-    created_at
-    updated_at
-  }
-}
-```
-
-## Mutations
+### Mutations
 
 ### `signup`
 
@@ -1196,9 +856,13 @@ mutation {
 }
 ```
 
----
+## Authorizer Admin APIs
 
-### `_admin_signup`
+All admin operations require super-admin authentication via either the `x-authorizer-admin-secret` header or the `authorizer.admin` HTTP-only session cookie (set by `_admin_login`). Except `_admin_login`, which may be called without an existing session. Admin operations are not exposed over REST or gRPC in the current release.
+
+### Admin Authentication
+
+#### `_admin_login`
 
 Mutation to signup administrator. This only works if `ADMIN_SECRET` env is not set. It accepts `params` of type `AdminSignupInput` with following keys
 
@@ -1242,7 +906,7 @@ mutation {
 }
 ```
 
-### `_admin_logout`
+#### `_admin_logout`
 
 Mutation to logout administrator. It does not have any params
 
@@ -1260,7 +924,135 @@ mutation {
 }
 ```
 
-### `_update_env`
+#### `_admin_session`
+
+Query to get admin session for dashboard
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+```json
+{
+  "x-authorizer-admin-secret": "ADMIN_SECRET"
+}
+```
+
+| Key       | Description                          |
+| --------- | ------------------------------------ |
+| `message` | Success response message from server |
+
+**Sample Query**
+
+```graphql
+query {
+  _admin_session {
+    message
+  }
+}
+```
+
+#### `_admin_meta`
+
+Query to get admin metadata (server info available to admins).
+
+**Sample Query**
+
+```graphql
+query {
+  _admin_meta {
+    version
+    client_id
+  }
+}
+```
+
+### Users
+
+#### `_users`
+
+Query to get all the `_users`. This query is only allowed for super admins. It returns array of users `Users` with below mentioned keys.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer.admin` as http only cookie.
+
+```json
+{
+  "x-authorizer-admin-secret": "ADMIN_SECRET"
+}
+```
+
+It can take optional `params` input of type `PaginatedInput` with following keys
+
+**Request Params**
+
+| Key     | Description                  | Required | Default |
+| ------- | ---------------------------- | -------- | ------- |
+| `page`  | Number of page that you want | false    | 1       |
+| `limit` | Number of rows that you want | false    | 10      |
+
+**Sample Query**
+
+```graphql
+query {
+  _users(params: {
+    pagination: {
+      page: 2
+      limit: 10
+    }
+  }) {
+    pagination: {
+      offset
+      total
+      page
+      limit
+    }
+    users {
+      id
+      given_name
+      family_name
+      email
+      picture
+      roles
+    }
+  }
+}
+```
+
+#### `_user`
+
+Query to get a specific user by either id or email.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer.admin` as http only cookie.
+
+```json
+{
+  "x-authorizer-admin-secret": "ADMIN_SECRET"
+}
+```
+
+It requires either of following parameters
+
+**Request Param**
+
+| Key     | Description            | Required |
+| ------- | ---------------------- | -------- |
+| `id`    | Identifier of the user | false    |
+| `email` | User's email address   | false    |
+
+**Sample Query**
+
+```graphql
+query {
+  _user(params: {
+    id: '123-123123-1231231'
+  }) {
+    id
+    email
+  }
+}
+```
+
+It returns the whole `User` object mentioned in [profile](#profile) query section
+
+#### `_update_user`
 
 Mutation to update environment variables. It accepts `params` of type `UpdateEnvInput` with keys present in environment variables
 
@@ -1324,7 +1116,7 @@ mutation {
 }
 ```
 
-### `_delete_user`
+#### `_delete_user`
 
 Mutation to delete user. This mutation is only allowed for super admins. It accepts `params` of type `DeleteUserInput` with following keys
 
@@ -1354,7 +1146,111 @@ mutation {
 }
 ```
 
-### `_invite_members`
+#### `_verification_requests`
+
+Query to get all the `_verification_requests`. This query is only allowed for super admins. It returns array of verification requests `[VerificationRequest!]!` with following keys.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+```json
+{
+  "x-authorizer-admin-secret": "ADMIN_SECRET"
+}
+```
+
+It can take optional `params` input of type `PaginatedInput` with following keys
+
+**Request Params**
+
+| Key     | Description                  | Required | Default |
+| ------- | ---------------------------- | -------- | ------- |
+| `page`  | Number of page that you want | false    | 1       |
+| `limit` | Number of rows that you want | false    | 10      |
+
+**Sample Query**
+
+```graphql
+query {
+  _verification_requests(params: { pagination: { limit: 10, page: 2 } }) {
+    pagination {
+      limit
+      offset
+      page
+    }
+    verification_requests {
+      id
+      token
+      email
+      expires
+      identifier
+    }
+  }
+}
+```
+
+### Access Control
+
+#### `_revoke_access`
+
+Mutation to revoke access of a given user. This mutation is only allowed for super admins. It accepts `params` of type `UpdateAccessInput` with following keys
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+**Request Params**
+
+| Key       | Description                              | Required |
+| --------- | ---------------------------------------- | -------- |
+| `user_id` | Id of user whose access is to be revoked | true     |
+
+This mutation returns `Response` type with following keys
+
+**Response**
+
+| Key       | Description                         |
+| --------- | ----------------------------------- |
+| `message` | Success / Error message from server |
+
+**Sample Mutation**
+
+```graphql
+mutation {
+  _revoke_access(params: { user_id: "test" }) {
+    message
+  }
+}
+```
+
+#### `_enable_access`
+
+Mutation to enable access of a given user whose access revoked earlier. This mutation is only allowed for super admins. It accepts `params` of type `UpdateAccessInput` with following keys
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+**Request Params**
+
+| Key       | Description                              | Required |
+| --------- | ---------------------------------------- | -------- |
+| `user_id` | Id of user whose access is to be enabled | true     |
+
+This mutation returns `Response` type with following keys
+
+**Response**
+
+| Key       | Description                         |
+| --------- | ----------------------------------- |
+| `message` | Success / Error message from server |
+
+**Sample Mutation**
+
+```graphql
+mutation {
+  _enable_access(params: { user_id: "test" }) {
+    message
+  }
+}
+```
+
+#### `_invite_members`
 
 Mutation to invite members. This mutation is only allowed for super admins. It accepts `params` of type `InviteMemberInput` with following keys
 
@@ -1385,100 +1281,9 @@ mutation {
 }
 ```
 
-### `_revoke_access`
+### Webhooks
 
-Mutation to revoke access of a given user. This mutation is only allowed for super admins. It accepts `params` of type `UpdateAccessInput` with following keys
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-**Request Params**
-
-| Key       | Description                              | Required |
-| --------- | ---------------------------------------- | -------- |
-| `user_id` | Id of user whose access is to be revoked | true     |
-
-This mutation returns `Response` type with following keys
-
-**Response**
-
-| Key       | Description                         |
-| --------- | ----------------------------------- |
-| `message` | Success / Error message from server |
-
-**Sample Mutation**
-
-```graphql
-mutation {
-  _revoke_access(params: { user_id: "test" }) {
-    message
-  }
-}
-```
-
-### `_enable_access`
-
-Mutation to enable access of a given user whose access revoked earlier. This mutation is only allowed for super admins. It accepts `params` of type `UpdateAccessInput` with following keys
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-**Request Params**
-
-| Key       | Description                              | Required |
-| --------- | ---------------------------------------- | -------- |
-| `user_id` | Id of user whose access is to be enabled | true     |
-
-This mutation returns `Response` type with following keys
-
-**Response**
-
-| Key       | Description                         |
-| --------- | ----------------------------------- |
-| `message` | Success / Error message from server |
-
-**Sample Mutation**
-
-```graphql
-mutation {
-  _enable_access(params: { user_id: "test" }) {
-    message
-  }
-}
-```
-
-### `_generate_jwt_keys`
-
-Mutation to generate new jwt keys based on given jwt algorithm. This mutation is only allowed for super admins. It accepts `params` of type `GenerateJWTKeysInput` with following keys
-
-> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
-
-**Request Params**
-
-| Key    | Description                                                                                                        | Required |
-| ------ | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `type` | JWT algorithm for which keys are to be generate. It supports HS256,HS384,HS512,RS256,RS384,RS512,ES256,ES384,ES512 | true     |
-
-This mutation returns `GenerateJWTKeysResponse` type with following keys
-
-**Response**
-
-| Key           | Description                                          |
-| ------------- | ---------------------------------------------------- |
-| `secret`      | In case of HMAC algorithm it returns secret          |
-| `public_key`  | In case of RSA / ECDSA it returns public key string  |
-| `private_key` | In case of RSA / ECDSA it returns private key string |
-
-**Sample Mutation**
-
-```graphql
-mutation {
-  _generate_jwt_keys(params: { type: "RS256" }) {
-    public_key
-    private_key
-  }
-}
-```
-
-### `_test_endpoint`
+#### `_test_endpoint`
 
 Mutation to test webhook endpoint. This mutation is allowed for admins only. It accepts `params` of type `TestEndpointRequest` with following keys and returns `TestEndpointResponse`
 
@@ -1524,7 +1329,7 @@ mutation {
 }
 ```
 
-### `_add_webhook`
+#### `_add_webhook`
 
 Mutation to add webhook. This mutation is allowed for admins only. It accepts `params` of type `AddWebhookRequest` with following keys
 
@@ -1570,7 +1375,7 @@ mutation {
 }
 ```
 
-### `_update_webhook`
+#### `_update_webhook`
 
 Mutation to update webhook. This mutation is allowed for admins only. It accepts `params` of type `UpdateWebhookRequest` with following keys
 
@@ -1608,7 +1413,7 @@ mutation {
 }
 ```
 
-### `_delete_webhook`
+#### `_delete_webhook`
 
 Mutation to delete webhook. This mutation is allowed for admins only. It accepts `params` of type `WebhookRequest` with following keys
 
@@ -1636,7 +1441,133 @@ mutation {
 }
 ```
 
-### `_add_email_template`
+#### `_webhook`
+
+Query to get webhook by its identifier. This query is allowed for admins only. It accepts `params` of type `WebhookRequest` with following keys and returns `Webhook`
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+**Request Params**
+
+| Key  | Description               | Required |
+| ---- | ------------------------- | -------- |
+| `id` | Identifier of the webhook | `true`   |
+
+**Response**
+
+| Key          | Description                                                                |
+| ------------ | -------------------------------------------------------------------------- |
+| `id`         | Identifier of the webhook                                                  |
+| `event_name` | Event for which the webhook will be executed                               |
+| `endpoint`   | Endpoint that is to be called                                              |
+| `enabled`    | Boolean to know if webhook is enabled or disabled                          |
+| `headers`    | JSON key, value pair object with the set of headers to be sent for webhook |
+| `created_at` | Time at which the webhook entry was created                                |
+| `updated_at` | Time at which the webhook entry was updated                                |
+
+**Sample Query**
+
+```graphql
+query {
+  _webhook(params: { id: "123-adfa-123412-asdfasda" }) {
+    id
+    event_name
+  }
+}
+```
+
+#### `_webhooks`
+
+Query to get list of webhooks. This query is allowed for admins only.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+It can take optional `params` input of type `PaginatedInput` with following keys
+
+**Request Params**
+
+| Key     | Description                  | Required | Default |
+| ------- | ---------------------------- | -------- | ------- |
+| `page`  | Number of page that you want | false    | 1       |
+| `limit` | Number of rows that you want | false    | 10      |
+
+**Response**
+
+It returns response of type `Webhooks` with following keys
+
+| Key        | Description                                             |
+| ---------- | ------------------------------------------------------- |
+| pagination | object with `limit`, `page`, `offset` & `total` value   |
+| webhooks   | List of webhook with params mentioned [here](#_webhook) |
+
+**Sample Query**
+
+```graphql
+_webhooks(params: {limit: 10, page: 1}) {
+  pagination {
+    limit
+    offset
+    total
+  }
+  webhooks {
+    id
+    event_name
+    endpoint
+  }
+}
+```
+
+#### `_webhook_logs`
+
+Query to get list of webhook logs. This query is allowed for admins only.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+It can take optional `params` input of type `ListWebhookLogRequest` with following keys
+
+**Request Params**
+
+| Key          | Description                         | Required | Default                |
+| ------------ | ----------------------------------- | -------- | ---------------------- |
+| `pagination` | Pagination object with limit & page | false    | `{limit: 10, page: 1}` |
+| `webhook_id` | Identifier for the webhook          | false    | null                   |
+
+**Response**
+
+It returns response of type `WebhookLogs` with following keys
+
+| Key          | Description                                                                                                |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| pagination   | object with `limit`, `page`, `offset` & `total` value                                                      |
+| webhook_logs | List of webhook log (`id`, `http_status`, `request`, `response`, `webhook_id`, `created_at`, `updated_at`) |
+
+**Sample Query**
+
+```graphql
+_webhook_logs(params: {
+  pagination: {
+    limit: 10
+  }
+  webhook_id: "test"
+}) {
+  pagination {
+    limit
+    offset
+    total
+  }
+  webhook_logs {
+    id
+    http_status
+    request
+    response
+    webhook_id
+  }
+}
+```
+
+### Email Templates
+
+#### `_add_email_template`
 
 Mutation to add email template that will be used while sending emails. This mutation is allowed for admins only. It accepts `params` of type `AddEmailTemplateRequest` with following keys
 
@@ -1667,7 +1598,7 @@ mutation {
 }
 ```
 
-### `_update_email_template`
+#### `_update_email_template`
 
 Mutation to update email template. This mutation is allowed for admins only. It accepts `params` of type `UpdateEmailTemplateRequest` with following keys
 
@@ -1703,7 +1634,7 @@ mutation {
 }
 ```
 
-### `_delete_email_template`
+#### `_delete_email_template`
 
 Mutation to delete email template. This mutation is allowed for admins only. It accepts `params` of type `DeleteEmailTemplateRequest` with following keys
 
@@ -1731,7 +1662,95 @@ mutation {
 }
 ```
 
-### Authorization (admin)
+#### `_email_templates`
+
+Query to get list of email templates. This query is allowed for admins only.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+It can take optional `params` input of type `PaginatedInput` with following keys
+
+**Request Params**
+
+| Key     | Description                  | Required | Default |
+| ------- | ---------------------------- | -------- | ------- |
+| `page`  | Number of page that you want | false    | 1       |
+| `limit` | Number of rows that you want | false    | 10      |
+
+**Response**
+
+It returns response of type `EmailTemplates` with following keys
+
+| Key             | Description                                           |
+| --------------- | ----------------------------------------------------- |
+| pagination      | object with `limit`, `page`, `offset` & `total` value |
+| email_templates | List of email template                                |
+
+**Sample Query**
+
+```graphql
+_email_templates(params: {limit: 10, page: 1}) {
+  pagination {
+    limit
+    offset
+    total
+  }
+  webhooks {
+    id
+    template
+    event_name
+    created_at
+    updated_at
+  }
+}
+```
+
+### Audit Logs
+
+#### `_audit_logs`
+
+Query to get a paginated list of audit log entries. This query is allowed for admins only.
+
+> Note: the super admin query can be access via special header with super admin secret (this is set via ENV) or `authorizer-admin` as http only cookie.
+
+It can take optional `params` input with pagination and filtering options.
+
+**Request Params**
+
+| Key          | Description                  | Required | Default |
+| ------------ | ---------------------------- | -------- | ------- |
+| `page`       | Number of page that you want | false    | 1       |
+| `limit`      | Number of rows that you want | false    | 10      |
+| `actor_id`   | Filter by actor ID           | false    | null    |
+| `action`     | Filter by action             | false    | null    |
+| `resource`   | Filter by resource type      | false    | null    |
+
+**Sample Query**
+
+```graphql
+query {
+  _audit_logs(params: {
+    pagination: { limit: 10, page: 1 },
+    actor_id: "user-123"
+  }) {
+    pagination {
+      limit
+      offset
+      page
+      total
+    }
+    entries {
+      id
+      actor_id
+      action
+      resource
+      created_at
+    }
+  }
+}
+```
+
+### Authorization (FGA)
 
 Manage the embedded FGA (ReBAC) engine: the authorization model and the relationship tuples. All require super-admin authentication (cookie or `X-Authorizer-Admin-Secret`). All admin authorization operations are namespaced with the `_fga_` prefix. See [Authorization (FGA)](./authorization) for the conceptual model.
 

--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -18,8 +18,18 @@ Table of Contents
 - [Public Methods](#public-methods)
   - [`Meta`](#meta)
   - [`Signup`](#signup)
+  - [`Login`](#login)
+  - [`MagicLinkLogin`](#magiclinklogin)
+  - [`VerifyEmail`](#verifyemail)
+  - [`ResendVerifyEmail`](#resendverifyemail)
+  - [`VerifyOtp`](#verifyotp)
+  - [`ResendOtp`](#resendotp)
+  - [`ForgotPassword`](#forgotpassword)
+  - [`ResetPassword`](#resetpassword)
   - [`Session`](#session)
   - [`Profile`](#profile)
+  - [`UpdateProfile`](#updateprofile)
+  - [`DeactivateAccount`](#deactivateaccount)
   - [`Logout`](#logout)
   - [`Revoke`](#revoke)
   - [`ValidateJwtToken`](#validatejwttoken)
@@ -129,12 +139,6 @@ languages.
 
 ## Public Methods
 
-> The gRPC / REST surface is being migrated incrementally. The methods below are
-> implemented today; the remaining authentication operations (login, magic-link, OTP,
-> email verification, forgot/reset password, profile update, account deactivation) are
-> currently served by the [GraphQL API](./graphql-api) and return `UNIMPLEMENTED` over
-> gRPC until their migration lands.
-
 Each message mirrors its GraphQL/REST counterpart — see the linked
 [GraphQL API reference](./graphql-api) anchor for field-level details.
 
@@ -146,6 +150,38 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 
 *Public.* Register a new user. Mirrors [`signup`](./graphql-api#signup).
 
+### `Login`
+
+*Public.* Authenticate with email/phone + password. Returns tokens, or an MFA challenge flag when OTP/TOTP is enabled. Mirrors [`login`](./graphql-api#login).
+
+### `MagicLinkLogin`
+
+*Public.* Start a passwordless login; emails a magic link. Mirrors [`magic_link_login`](./graphql-api#magic_link_login).
+
+### `VerifyEmail`
+
+*Public.* Complete email verification using the token from the verification email. Mirrors [`verify_email`](./graphql-api#verify_email).
+
+### `ResendVerifyEmail`
+
+*Public.* Re-send the email-verification message. Mirrors [`resend_verify_email`](./graphql-api#resend_verify_email).
+
+### `VerifyOtp`
+
+*Public.* Complete an MFA challenge by submitting the email/phone OTP. Mirrors [`verify_otp`](./graphql-api#verify_otp).
+
+### `ResendOtp`
+
+*Public.* Re-send the MFA OTP. Mirrors [`resend_otp`](./graphql-api#resend_otp).
+
+### `ForgotPassword`
+
+*Public.* Start password reset; emails a reset link. Mirrors [`forgot_password`](./graphql-api#forgot_password).
+
+### `ResetPassword`
+
+*Public.* Set a new password using the reset token. Mirrors [`reset_password`](./graphql-api#reset_password).
+
 ### `Session`
 
 *Authenticated.* Refresh / fetch the current session. Mirrors [`session`](./graphql-api#session).
@@ -153,6 +189,14 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 ### `Profile`
 
 *Authenticated.* The authenticated user's profile. Mirrors [`profile`](./graphql-api#profile).
+
+### `UpdateProfile`
+
+*Authenticated.* Update the authenticated user's profile. Mirrors [`update_profile`](./graphql-api#update_profile).
+
+### `DeactivateAccount`
+
+*Authenticated.* Deactivate (soft-delete) the authenticated user's account. Mirrors [`deactivate_account`](./graphql-api#deactivate_account).
 
 ### `Logout`
 
@@ -384,7 +428,6 @@ statuses. Common cases:
 | `PERMISSION_DENIED`     | Explicit `user` not permitted for the caller.        |
 | `FAILED_PRECONDITION`   | FGA not enabled (`--fga-store` unset).               |
 | `INVALID_ARGUMENT`      | Validation failure (e.g. `> 100` checks).            |
-| `UNIMPLEMENTED`         | Method not yet migrated to gRPC — use GraphQL.       |
 
 ## See also
 

--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -180,7 +180,7 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 
 ## Authorizer Admin Methods
 
-The `AuthorizerAdminService` is served on the same gRPC port and address as `AuthorizerService`. All admin methods require super-admin authentication via request metadata (`authorization: Bearer <admin_token>`) or an admin session cookie. Except `AdminLogin`, which does not require an existing session.
+The `AuthorizerAdminService` is served on the same gRPC port and address as `AuthorizerService`. All admin methods require super-admin authentication via the `x-authorizer-admin-secret` request metadata (the admin secret configured with `--admin-secret`) or an `authorizer.admin` session cookie. Except `AdminLogin`, which does not require an existing session.
 
 ### Admin Authentication
 

--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -15,7 +15,7 @@ Table of Contents
 
 - [Service & transport](#service--transport)
 - [Protobuf schema](#protobuf-schema)
-- [Available methods](#available-methods)
+- [Public Methods](#public-methods)
   - [`Meta`](#meta)
   - [`Signup`](#signup)
   - [`Session`](#session)
@@ -26,6 +26,46 @@ Table of Contents
   - [`ValidateSession`](#validatesession)
   - [`CheckPermissions`](#checkpermissions)
   - [`ListPermissions`](#listpermissions)
+- [Authorizer Admin Methods](#authorizer-admin-methods)
+  - [Admin Authentication](#admin-authentication)
+    - [`AdminLogin`](#adminlogin)
+    - [`AdminLogout`](#adminlogout)
+    - [`AdminSession`](#adminsession)
+    - [`AdminMeta`](#adminmeta)
+  - [User Management](#user-management)
+    - [`Users`](#users)
+    - [`User`](#user)
+    - [`UpdateUser`](#updateuser)
+    - [`DeleteUser`](#deleteuser)
+    - [`VerificationRequests`](#verificationrequests)
+  - [Access Control](#access-control)
+    - [`RevokeAccess`](#revokeaccess)
+    - [`EnableAccess`](#enableaccess)
+    - [`InviteMembers`](#invitemembers)
+  - [Webhook Management](#webhook-management)
+    - [`AddWebhook`](#addwebhook)
+    - [`UpdateWebhook`](#updatewebhook)
+    - [`DeleteWebhook`](#deletewebhook)
+    - [`GetWebhook`](#getwebhook)
+    - [`Webhooks`](#webhooks)
+    - [`WebhookLogs`](#webhooklogs)
+    - [`TestEndpoint`](#testendpoint)
+  - [Email Template Management](#email-template-management)
+    - [`AddEmailTemplate`](#addemailtemplate)
+    - [`UpdateEmailTemplate`](#updateemailtemplate)
+    - [`DeleteEmailTemplate`](#deleteemailtemplate)
+    - [`EmailTemplates`](#emailtemplates)
+  - [Audit Logs](#audit-logs)
+    - [`AuditLogs`](#auditlogs)
+  - [Authorization (FGA)](#authorization-fga)
+    - [`FgaGetModel`](#fgagetmodel)
+    - [`FgaWriteModel`](#fgawritemodel)
+    - [`FgaWriteTuples`](#fgawritetuples)
+    - [`FgaDeleteTuples`](#fgadeletetuples)
+    - [`FgaReadTuples`](#fgaread-tuples)
+    - [`FgaListUsers`](#fgalistusers)
+    - [`FgaExpand`](#fgaexpand)
+    - [`FgaReset`](#fgareset)
 - [Calling with `grpcurl`](#calling-with-grpcurl)
 - [Health checks](#health-checks)
 - [Errors](#errors)
@@ -36,9 +76,9 @@ Table of Contents
 | Property              | Value                                                              |
 | --------------------- | ------------------------------------------------------------------ |
 | Proto package         | `authorizer.v1`                                                    |
-| Service               | `AuthorizerService`                                                |
+| Services              | `AuthorizerService` (public) + `AuthorizerAdminService` (admin)   |
 | BSR module            | [`buf.build/authorizerdev/authorizer`](https://buf.build/authorizerdev/authorizer) |
-| Port                  | `--grpc-port` (default `9091`)                                     |
+| Port                  | `--grpc-port` (default `9091`) — same server, both services       |
 | TLS                   | `--grpc-tls-cert` + `--grpc-tls-key`; `--grpc-insecure` for dev    |
 | Server reflection     | `--enable-grpc-reflection` (default `true`)                        |
 | Health checking       | `grpc.health.v1.Health` (always registered)                       |
@@ -87,7 +127,7 @@ languages.
   [JavaScript](../sdks/authorizer-js/), and [Python](../sdks/authorizer-python/) SDKs wrap
   the API for you.
 
-## Available methods
+## Public Methods
 
 > The gRPC / REST surface is being migrated incrementally. The methods below are
 > implemented today; the remaining authentication operations (login, magic-link, OTP,
@@ -137,6 +177,154 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 ### `ListPermissions`
 
 *Authenticated.* List objects/relations the subject can access. Mirrors [`list_permissions`](./graphql-api#list_permissions).
+
+## Authorizer Admin Methods
+
+The `AuthorizerAdminService` is served on the same gRPC port and address as `AuthorizerService`. All admin methods require super-admin authentication via request metadata (`authorization: Bearer <admin_token>`) or an admin session cookie. Except `AdminLogin`, which does not require an existing session.
+
+### Admin Authentication
+
+#### `AdminLogin`
+
+*Public (for admin-secret).* Authenticate as super-admin with the admin secret. Returns an auth response with session token.
+
+#### `AdminLogout`
+
+*Admin-only.* Invalidate the current admin session.
+
+#### `AdminSession`
+
+*Admin-only.* Verify the current admin session is valid.
+
+#### `AdminMeta`
+
+*Admin-only.* Get admin-level server metadata (version, feature flags with admin-only fields).
+
+### User Management
+
+#### `Users`
+
+*Admin-only.* List all users with pagination. Mirrors [`_users`](./graphql-api#_users).
+
+#### `User`
+
+*Admin-only.* Get a specific user by id or email. Mirrors [`_user`](./graphql-api#_user).
+
+#### `UpdateUser`
+
+*Admin-only.* Update user profile fields (email, roles, name, etc.). Mirrors [`_update_user`](./graphql-api#_update_user).
+
+#### `DeleteUser`
+
+*Admin-only.* Delete a user by email and all associated OTP/verification data. Mirrors [`_delete_user`](./graphql-api#_delete_user).
+
+#### `VerificationRequests`
+
+*Admin-only.* List pending verification requests with optional pagination. Mirrors [`_verification_requests`](./graphql-api#_verification_requests).
+
+### Access Control
+
+#### `RevokeAccess`
+
+*Admin-only.* Revoke a user's access (set revoked_timestamp) and fire the `user.access_revoked` webhook. Mirrors [`_revoke_access`](./graphql-api#_revoke_access).
+
+#### `EnableAccess`
+
+*Admin-only.* Re-enable a previously revoked user (clear revoked_timestamp) and fire the `user.access_enabled` webhook. Mirrors [`_enable_access`](./graphql-api#_enable_access).
+
+#### `InviteMembers`
+
+*Admin-only.* Invite users to the platform by email with an invitation link. Mirrors [`_invite_members`](./graphql-api#_invite_members).
+
+### Webhook Management
+
+#### `AddWebhook`
+
+*Admin-only.* Register a new webhook for an event. Mirrors [`_add_webhook`](./graphql-api#_add_webhook).
+
+#### `UpdateWebhook`
+
+*Admin-only.* Update an existing webhook (endpoint, headers, enabled state, etc.). Mirrors [`_update_webhook`](./graphql-api#_update_webhook).
+
+#### `DeleteWebhook`
+
+*Admin-only.* Delete a webhook by id. Mirrors [`_delete_webhook`](./graphql-api#_delete_webhook).
+
+#### `GetWebhook`
+
+*Admin-only.* Get a webhook by id. Mirrors [`_webhook`](./graphql-api#_webhook).
+
+#### `Webhooks`
+
+*Admin-only.* List all webhooks with pagination. Mirrors [`_webhooks`](./graphql-api#_webhooks).
+
+#### `WebhookLogs`
+
+*Admin-only.* List webhook delivery logs with optional pagination and webhook_id filter. Mirrors [`_webhook_logs`](./graphql-api#_webhook_logs).
+
+#### `TestEndpoint`
+
+*Admin-only.* Send a test webhook payload to an endpoint and return the HTTP response. Mirrors [`_test_endpoint`](./graphql-api#_test_endpoint).
+
+### Email Template Management
+
+#### `AddEmailTemplate`
+
+*Admin-only.* Create a new email template for an event. Mirrors [`_add_email_template`](./graphql-api#_add_email_template).
+
+#### `UpdateEmailTemplate`
+
+*Admin-only.* Update an email template. Mirrors [`_update_email_template`](./graphql-api#_update_email_template).
+
+#### `DeleteEmailTemplate`
+
+*Admin-only.* Delete an email template by id. Mirrors [`_delete_email_template`](./graphql-api#_delete_email_template).
+
+#### `EmailTemplates`
+
+*Admin-only.* List email templates with pagination. Mirrors [`_email_templates`](./graphql-api#_email_templates).
+
+### Audit Logs
+
+#### `AuditLogs`
+
+*Admin-only.* Retrieve audit log entries with optional filtering by actor, action, or resource and pagination. Mirrors [`_audit_logs`](./graphql-api#_audit_logs).
+
+### Authorization (FGA)
+
+Manage the embedded fine-grained authorization (FGA) engine. See [Authorization (FGA)](./authorization) for the conceptual model.
+
+#### `FgaGetModel`
+
+*Admin-only.* Retrieve the active authorization model as FGA DSL. An empty store returns an empty model (not an error).
+
+#### `FgaWriteModel`
+
+*Admin-only.* Install a new authorization model version from FGA DSL. Models are versioned and append-only. Audited.
+
+#### `FgaWriteTuples`
+
+*Admin-only.* Write (persist) relationship tuples. Audited.
+
+#### `FgaDeleteTuples`
+
+*Admin-only.* Delete relationship tuples. Audited.
+
+#### `FgaReadTuples` {#fgaread-tuples}
+
+*Admin-only.* Read stored tuples with optional filtering by user, relation, or object and pagination.
+
+#### `FgaListUsers`
+
+*Admin-only.* List fully-qualified user ids that have a relation on an object (reveals the access graph).
+
+#### `FgaExpand`
+
+*Admin-only.* Expand the relationship/userset tree for a relation on an object (useful for debugging).
+
+#### `FgaReset`
+
+*Admin-only.* Delete the entire fine-grained authorization store (model, all versions, and all tuples) and start fresh. Refused if any tuples still exist. Destructive and audited.
 
 ## Calling with `grpcurl`
 

--- a/docs/core/metrics-monitoring.md
+++ b/docs/core/metrics-monitoring.md
@@ -67,6 +67,9 @@ For routes that do not match a registered Gin pattern, `path` is recorded as `un
 |--------|------|--------|-------------|
 | `authorizer_auth_events_total` | Counter | `event`, `status` | Authentication event count |
 | `authorizer_active_sessions` | Gauge | — | Approximate active session count |
+| `authorizer_api_operations_total` | Counter | `protocol`, `operation`, `status` | API operations served, attributed to the protocol they came in on |
+
+The `protocol` label on `authorizer_api_operations_total` is one of `graphql`, `grpc`, or `rest` (the `rest` value covers calls made through the grpc-gateway `/v1/*` surface). `operation` is the gRPC method / GraphQL operation name and `status` is `ok` or `error`. The same protocol is also recorded on each audit-log entry (under the `protocol` key of the entry's `metadata` field), so operations are attributable to their transport in both metrics and the audit trail.
 
 **Auth event values:**
 

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -21,8 +21,8 @@ resistance.
 > the same service layer, so they behave identically.
 
 > **Availability:** the `/v1` REST gateway is mounted only when the gRPC server is enabled
-> (the default). The surface is being migrated incrementally — see
-> [Available endpoints](#public-api-endpoints) below for what is live today.
+> (the default). It mirrors the full public and admin service surface — see
+> [Available endpoints](#public-api-endpoints) below.
 
 Table of Contents
 
@@ -30,8 +30,18 @@ Table of Contents
 - [Authentication](#authentication)
 - [Public Endpoints](#public-api-endpoints)
   - [`POST /v1/signup`](#post-v1signup)
+  - [`POST /v1/login`](#post-v1login)
+  - [`POST /v1/magic_link_login`](#post-v1magic_link_login)
+  - [`POST /v1/verify_email`](#post-v1verify_email)
+  - [`POST /v1/resend_verify_email`](#post-v1resend_verify_email)
+  - [`POST /v1/verify_otp`](#post-v1verify_otp)
+  - [`POST /v1/resend_otp`](#post-v1resend_otp)
+  - [`POST /v1/forgot_password`](#post-v1forgot_password)
+  - [`POST /v1/reset_password`](#post-v1reset_password)
   - [`POST /v1/logout`](#post-v1logout)
   - [`GET /v1/profile`](#get-v1profile)
+  - [`POST /v1/update_profile`](#post-v1update_profile)
+  - [`POST /v1/deactivate_account`](#post-v1deactivate_account)
   - [`POST /v1/session`](#post-v1session)
   - [`POST /v1/revoke`](#post-v1revoke)
   - [`POST /v1/validate_jwt_token`](#post-v1validate_jwt_token)
@@ -124,15 +134,49 @@ Every endpoint below accepts/returns the same fields as its GraphQL counterpart.
 full field-by-field breakdown of each request and response, follow the linked anchor in
 the [GraphQL API reference](./graphql-api).
 
-> **Migration in progress.** The remaining authentication operations — `login`,
-> `magic_link_login`, `verify_email`, `resend_verify_email`, `verify_otp`, `resend_otp`,
-> `forgot_password`, `reset_password`, `update_profile`, and `deactivate_account` — are
-> defined in the schema but not yet served over REST/gRPC; they return `501`/`UNIMPLEMENTED`
-> for now. Use the [GraphQL API](./graphql-api) for these flows until their migration lands.
-
 ### `POST /v1/signup`
 
 Register a new user. Request/response fields match [`signup`](./graphql-api#signup).
+
+### `POST /v1/login`
+
+Authenticate with email/phone + password. Returns tokens, or an MFA challenge flag
+(`should_show_email_otp_screen` / `should_show_totp_screen`) when OTP/TOTP is enabled.
+Mirrors [`login`](./graphql-api#login).
+
+```bash
+curl -X POST https://auth.example.com/v1/login \
+  -H "Content-Type: application/json" \
+  -d '{ "email": "jane@example.com", "password": "Test@123", "scope": ["openid", "profile", "email"] }'
+```
+
+### `POST /v1/magic_link_login`
+
+Start a passwordless login; emails a magic link. Mirrors [`magic_link_login`](./graphql-api#magic_link_login).
+
+### `POST /v1/verify_email`
+
+Complete email verification using the token from the verification email. Mirrors [`verify_email`](./graphql-api#verify_email).
+
+### `POST /v1/resend_verify_email`
+
+Re-send the email-verification message. Mirrors [`resend_verify_email`](./graphql-api#resend_verify_email).
+
+### `POST /v1/verify_otp`
+
+Complete an MFA challenge by submitting the email/phone OTP. Mirrors [`verify_otp`](./graphql-api#verify_otp).
+
+### `POST /v1/resend_otp`
+
+Re-send the MFA OTP. Mirrors [`resend_otp`](./graphql-api#resend_otp).
+
+### `POST /v1/forgot_password`
+
+Start password reset; emails a reset link. Mirrors [`forgot_password`](./graphql-api#forgot_password).
+
+### `POST /v1/reset_password`
+
+Set a new password using the reset token. Mirrors [`reset_password`](./graphql-api#reset_password).
 
 ### `POST /v1/logout`
 
@@ -141,6 +185,14 @@ Invalidate the current session *(auth)*. Mirrors [`logout`](./graphql-api#logout
 ### `GET /v1/profile`
 
 Get the authenticated user's profile *(auth)*. Mirrors [`profile`](./graphql-api#profile).
+
+### `POST /v1/update_profile`
+
+Update the authenticated user's profile *(auth)*. Mirrors [`update_profile`](./graphql-api#update_profile).
+
+### `POST /v1/deactivate_account`
+
+Deactivate (soft-delete) the authenticated user's account *(auth)*. Mirrors [`deactivate_account`](./graphql-api#deactivate_account).
 
 ### `POST /v1/session`
 
@@ -259,7 +311,7 @@ exist — narrow the query with `relation` / `object_type` to page through them.
 
 All admin endpoints require super-admin authentication via the `x-authorizer-admin-secret` request header or an `authorizer.admin` session cookie (set by `POST /v1/admin/login`). Except `POST /v1/admin/login`, which may be called without an existing session. The operations are grouped by domain below; each mirrors its GraphQL counterpart for request/response fields.
 
-> **Note:** In the current release, admin endpoints are REST-only; they are not yet exposed over native gRPC (they return `UNIMPLEMENTED` if called via gRPC). Use the REST endpoints or the [GraphQL API](./graphql-api) for admin operations.
+> **Note:** Admin operations are available over all three surfaces — REST (below), native gRPC (`AuthorizerAdminService`, see the [gRPC API](./grpc#authorizer-admin-methods)), and the [GraphQL API](./graphql-api) (the `_`-prefixed operations).
 
 ### Admin Authentication
 
@@ -648,7 +700,6 @@ Common cases:
 | Explicit `user` not permitted for caller   | `403 Forbidden`    |
 | FGA not enabled (`--fga-store` unset)      | `400 Bad Request`  |
 | Validation failure (e.g. `> 100` checks)   | `400 Bad Request`  |
-| Endpoint not yet migrated to REST/gRPC     | `501 Not Implemented` |
 
 ## See also
 

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -22,13 +22,13 @@ resistance.
 
 > **Availability:** the `/v1` REST gateway is mounted only when the gRPC server is enabled
 > (the default). The surface is being migrated incrementally — see
-> [Available endpoints](#endpoint-reference) below for what is live today.
+> [Available endpoints](#public-api-endpoints) below for what is live today.
 
 Table of Contents
 
 - [Base URL & transport](#base-url--transport)
 - [Authentication](#authentication)
-- [Endpoint reference](#endpoint-reference)
+- [Public Endpoints](#public-api-endpoints)
   - [`POST /v1/signup`](#post-v1signup)
   - [`POST /v1/logout`](#post-v1logout)
   - [`GET /v1/profile`](#get-v1profile)
@@ -39,6 +39,46 @@ Table of Contents
   - [`GET /v1/meta`](#get-v1meta)
   - [`POST /v1/check_permissions`](#post-v1check_permissions)
   - [`POST /v1/list_permissions`](#post-v1list_permissions)
+- [Authorizer Admin API Endpoints](#authorizer-admin-api-endpoints)
+  - [Admin Authentication](#admin-authentication)
+    - [`POST /v1/admin/login`](#post-v1adminlogin)
+    - [`POST /v1/admin/logout`](#post-v1adminlogout)
+    - [`GET /v1/admin/session`](#get-v1adminsession)
+    - [`GET /v1/admin/meta`](#get-v1adminmeta)
+  - [Users](#users)
+    - [`POST /v1/admin/users`](#post-v1adminusers)
+    - [`POST /v1/admin/user`](#post-v1adminuser)
+    - [`POST /v1/admin/update_user`](#post-v1adminupdate_user)
+    - [`POST /v1/admin/delete_user`](#post-v1admindelete_user)
+    - [`POST /v1/admin/verification_requests`](#post-v1adminverification_requests)
+  - [Access Control](#access-control)
+    - [`POST /v1/admin/revoke_access`](#post-v1adminrevoke_access)
+    - [`POST /v1/admin/enable_access`](#post-v1adminenable_access)
+    - [`POST /v1/admin/invite_members`](#post-v1admininvite_members)
+  - [Webhooks](#webhooks)
+    - [`POST /v1/admin/add_webhook`](#post-v1adminadd_webhook)
+    - [`POST /v1/admin/update_webhook`](#post-v1adminupdate_webhook)
+    - [`POST /v1/admin/delete_webhook`](#post-v1admindelete_webhook)
+    - [`POST /v1/admin/webhook`](#post-v1adminwebhook)
+    - [`POST /v1/admin/webhooks`](#post-v1adminwebhooks)
+    - [`POST /v1/admin/webhook_logs`](#post-v1adminwebhook_logs)
+    - [`POST /v1/admin/test_endpoint`](#post-v1admintest_endpoint)
+  - [Email Templates](#email-templates)
+    - [`POST /v1/admin/add_email_template`](#post-v1adminadd_email_template)
+    - [`POST /v1/admin/update_email_template`](#post-v1adminupdate_email_template)
+    - [`POST /v1/admin/delete_email_template`](#post-v1admindelete_email_template)
+    - [`POST /v1/admin/email_templates`](#post-v1adminemail_templates)
+  - [Audit Logs](#audit-logs)
+    - [`POST /v1/admin/audit_logs`](#post-v1adminaudit_logs)
+  - [Authorization (FGA)](#authorization-fga)
+    - [`GET /v1/admin/fga/model`](#get-v1adminfgamodel)
+    - [`POST /v1/admin/fga/model`](#post-v1adminfgamodel)
+    - [`POST /v1/admin/fga/tuples`](#post-v1-admin-fga-tuples)
+    - [`POST /v1/admin/fga/tuples/delete`](#post-v1adminfgatuplesdelete)
+    - [`POST /v1/admin/fga/tuples/read`](#post-v1adminfgatuplesread)
+    - [`POST /v1/admin/fga/list_users`](#post-v1adminfgalist_users)
+    - [`POST /v1/admin/fga/expand`](#post-v1adminfgaexpand)
+    - [`POST /v1/admin/fga/reset`](#post-v1adminfgareset)
 - [Errors](#errors)
 - [See also](#see-also)
 
@@ -78,14 +118,11 @@ require the admin secret / admin session. See [GraphQL API](./graphql-api) for t
 > automatically; server-side clients should set `Origin` explicitly. The official SDKs do
 > this for you.
 
-## Endpoint reference
+## Public API Endpoints
 
 Every endpoint below accepts/returns the same fields as its GraphQL counterpart. For the
 full field-by-field breakdown of each request and response, follow the linked anchor in
 the [GraphQL API reference](./graphql-api).
-
-Super-admin-only operations (the `_fga_*` model/tuple management mutations, env, users,
-webhooks, etc.) are **not** part of the REST surface — they remain GraphQL-only.
 
 > **Migration in progress.** The remaining authentication operations — `login`,
 > `magic_link_login`, `verify_email`, `resend_verify_email`, `verify_otp`, `resend_otp`,
@@ -217,6 +254,379 @@ curl -X POST https://auth.example.com/v1/list_permissions \
 
 `truncated` is `true` when the result was capped at **1000** entries and more permissions
 exist — narrow the query with `relation` / `object_type` to page through them.
+
+## Authorizer Admin API Endpoints
+
+All admin endpoints require super-admin authentication via the `x-authorizer-admin-secret` request header or an `authorizer.admin` session cookie (set by `POST /v1/admin/login`). Except `POST /v1/admin/login`, which may be called without an existing session. The operations are grouped by domain below; each mirrors its GraphQL counterpart for request/response fields.
+
+> **Note:** In the current release, admin endpoints are REST-only; they are not yet exposed over native gRPC (they return `UNIMPLEMENTED` if called via gRPC). Use the REST endpoints or the [GraphQL API](./graphql-api) for admin operations.
+
+### Admin Authentication
+
+#### `POST /v1/admin/login`
+
+Authenticate as super-admin with the admin secret. Returns a session token.
+
+**Request body**
+
+| Field           | Type     | Description             | Required |
+| --------------- | -------- | ----------------------- | -------- |
+| `admin_secret`  | `string` | The admin secret value. | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/logout`
+
+Invalidate the current admin session.
+
+**Response** `{ message: string }`
+
+#### `GET /v1/admin/session`
+
+Verify the current admin session is valid.
+
+**Response** `{ message: string }`
+
+#### `GET /v1/admin/meta`
+
+Get admin-level metadata about the server (version, feature flags).
+
+**Response** — same as [`GET /v1/meta`](#get-v1meta) but with admin-only fields
+
+### Users
+
+#### `POST /v1/admin/users`
+
+List all users with pagination.
+
+**Request body**
+
+| Field        | Type                | Description  | Required |
+| ------------ | ------------------- | ------------ | -------- |
+| `pagination` | `{ page, limit }`   | Page & limit. | no       |
+
+**Response** `{ users: User[], pagination: { page, limit, total, offset } }`
+
+#### `POST /v1/admin/user`
+
+Get a specific user by id or email.
+
+**Request body**
+
+| Field | Type     | Description     | Required |
+| ----- | -------- | --------------- | -------- |
+| `id`  | `string` | User id.        | no       |
+| `email` | `string` | User email.    | no       |
+
+**Response** `User`
+
+#### `POST /v1/admin/update_user`
+
+Update user profile fields (email, roles, name, etc.).
+
+**Request body** — see [`_update_user`](./graphql-api#_update_user) for the full field list.
+
+**Response** `User`
+
+#### `POST /v1/admin/delete_user`
+
+Delete a user by email (and all associated OTP/verification data).
+
+**Request body**
+
+| Field   | Type     | Description | Required |
+| ------- | -------- | ----------- | -------- |
+| `email` | `string` | User email. | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/verification_requests`
+
+List pending verification requests (email, phone OTP, etc.) with optional pagination.
+
+**Request body**
+
+| Field        | Type              | Description  | Required |
+| ------------ | ----------------- | ------------ | -------- |
+| `pagination` | `{ page, limit }` | Page & limit. | no       |
+
+**Response** `{ verification_requests: VerificationRequest[], pagination: { ... } }`
+
+### Access Control
+
+#### `POST /v1/admin/revoke_access`
+
+Revoke a user's access (set revoked_timestamp), firing the `user.access_revoked` webhook.
+
+**Request body**
+
+| Field   | Type     | Description | Required |
+| ------- | -------- | ----------- | -------- |
+| `user_id` | `string` | User id.  | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/enable_access`
+
+Re-enable a previously revoked user (clear revoked_timestamp), firing the `user.access_enabled` webhook.
+
+**Request body**
+
+| Field   | Type     | Description | Required |
+| ------- | -------- | ----------- | -------- |
+| `user_id` | `string` | User id.  | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/invite_members`
+
+Invite users to the platform by email, sending them an invitation link.
+
+**Request body**
+
+| Field          | Type       | Description                            | Required |
+| -------------- | ---------- | -------------------------------------- | -------- |
+| `emails`       | `string[]` | Email addresses to invite.             | yes      |
+| `redirect_uri` | `string`   | Where to redirect after signup.        | no       |
+
+**Response** `{ message: string }`
+
+### Webhooks
+
+#### `POST /v1/admin/add_webhook`
+
+Register a new webhook for an event.
+
+**Request body** — see [`_add_webhook`](./graphql-api#_add_webhook) for field details.
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/update_webhook`
+
+Update an existing webhook (endpoint, headers, enabled state, etc.).
+
+**Request body** — see [`_update_webhook`](./graphql-api#_update_webhook) for field details.
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/delete_webhook`
+
+Delete a webhook by id.
+
+**Request body**
+
+| Field | Type     | Description  | Required |
+| ----- | -------- | ------------ | -------- |
+| `id`  | `string` | Webhook id.  | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/webhook`
+
+Get a webhook by id.
+
+**Request body**
+
+| Field | Type     | Description  | Required |
+| ----- | -------- | ------------ | -------- |
+| `id`  | `string` | Webhook id.  | yes      |
+
+**Response** `Webhook`
+
+#### `POST /v1/admin/webhooks`
+
+List all webhooks with pagination.
+
+**Request body**
+
+| Field        | Type              | Description  | Required |
+| ------------ | ----------------- | ------------ | -------- |
+| `pagination` | `{ page, limit }` | Page & limit. | no       |
+
+**Response** `{ webhooks: Webhook[], pagination: { ... } }`
+
+#### `POST /v1/admin/webhook_logs`
+
+List webhook delivery logs with optional pagination and webhook_id filter.
+
+**Request body**
+
+| Field        | Type              | Description      | Required |
+| ------------ | ----------------- | -------------- | -------- |
+| `pagination` | `{ page, limit }` | Page & limit.  | no       |
+| `webhook_id` | `string`          | Filter by hook. | no       |
+
+**Response** `{ webhook_logs: WebhookLog[], pagination: { ... } }`
+
+#### `POST /v1/admin/test_endpoint`
+
+Send a test webhook payload to an endpoint and return the response.
+
+**Request body**
+
+| Field        | Type                | Description          | Required |
+| ------------ | ------------------- | -------------------- | -------- |
+| `event_name` | `string`            | Event to simulate.   | yes      |
+| `endpoint`   | `string`            | URL to call.         | yes      |
+| `headers`    | `map[string]string` | Extra HTTP headers.  | no       |
+
+**Response** `{ http_status: int, response: string }`
+
+### Email Templates
+
+#### `POST /v1/admin/add_email_template`
+
+Create a new email template for an event.
+
+**Request body** — see [`_add_email_template`](./graphql-api#_add_email_template) for field details.
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/update_email_template`
+
+Update an email template.
+
+**Request body** — see [`_update_email_template`](./graphql-api#_update_email_template) for field details.
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/delete_email_template`
+
+Delete an email template by id.
+
+**Request body**
+
+| Field | Type     | Description  | Required |
+| ----- | -------- | ------------ | -------- |
+| `id`  | `string` | Template id. | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/email_templates`
+
+List email templates with pagination.
+
+**Request body**
+
+| Field        | Type              | Description  | Required |
+| ------------ | ----------------- | ------------ | -------- |
+| `pagination` | `{ page, limit }` | Page & limit. | no       |
+
+**Response** `{ email_templates: EmailTemplate[], pagination: { ... } }`
+
+### Audit Logs
+
+#### `POST /v1/admin/audit_logs`
+
+Retrieve audit log entries with optional filtering and pagination.
+
+**Request body**
+
+| Field        | Type              | Description              | Required |
+| ------------ | ----------------- | ----------------------- | -------- |
+| `pagination` | `{ page, limit }` | Page & limit.            | no       |
+| `actor_id`   | `string`          | Filter by actor id.      | no       |
+| `action`     | `string`          | Filter by action type.   | no       |
+| `resource`   | `string`          | Filter by resource type. | no       |
+
+**Response** `{ audit_logs: AuditLog[], pagination: { ... } }`
+
+### Authorization (FGA)
+
+Manage the embedded fine-grained authorization (FGA) engine: the authorization model and relationship tuples. See [Authorization (FGA)](./authorization) for the conceptual model.
+
+#### `GET /v1/admin/fga/model`
+
+Retrieve the active authorization model as FGA DSL. An empty store returns an empty model (not an error).
+
+**Response** `{ id: string, dsl: string }`
+
+#### `POST /v1/admin/fga/model`
+
+Install a new authorization model version from FGA DSL. Models are versioned and append-only.
+
+**Request body**
+
+| Field | Type     | Description | Required |
+| ----- | -------- | ----------- | -------- |
+| `dsl` | `string` | FGA DSL.    | yes      |
+
+**Response** `{ id: string, dsl: string }`
+
+#### `POST /v1/admin/fga/tuples` {#post-v1-admin-fga-tuples}
+
+Write (persist) relationship tuples.
+
+**Request body**
+
+| Field   | Type                      | Description         | Required |
+| ------- | ------------------------- | ------------------- | -------- |
+| `tuples` | `{ user, relation, object }[]` | Tuples to write.  | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/fga/tuples/delete`
+
+Delete relationship tuples.
+
+**Request body**
+
+| Field   | Type                      | Description         | Required |
+| ------- | ------------------------- | ------------------- | -------- |
+| `tuples` | `{ user, relation, object }[]` | Tuples to delete. | yes      |
+
+**Response** `{ message: string }`
+
+#### `POST /v1/admin/fga/tuples/read`
+
+Read stored tuples with optional filtering and pagination.
+
+**Request body**
+
+| Field               | Type      | Description              | Required |
+| ------------------- | --------- | ------------------------ | -------- |
+| `user`              | `string`  | Filter by user.          | no       |
+| `relation`          | `string`  | Filter by relation.      | no       |
+| `object`            | `string`  | Filter by object.        | no       |
+| `page_size`         | `int`     | Max tuples per page.     | no       |
+| `continuation_token`| `string`  | Pagination token.        | no       |
+
+**Response** `{ tuples: { user, relation, object }[], continuation_token: string }`
+
+#### `POST /v1/admin/fga/list_users`
+
+List fully-qualified user ids that have a relation on an object (reveals the access graph; admin-only).
+
+**Request body**
+
+| Field      | Type     | Description            | Required |
+| ---------- | -------- | ---------------------- | -------- |
+| `object`   | `string` | Object to inspect.     | yes      |
+| `relation` | `string` | Relation to resolve.   | yes      |
+| `user_type`| `string` | Type of users to list. | yes      |
+
+**Response** `{ users: string[] }`
+
+#### `POST /v1/admin/fga/expand`
+
+Expand the relationship/userset tree for a relation on an object (admin-only; useful for debugging). Returns the OpenFGA userset tree as a JSON string.
+
+**Request body**
+
+| Field      | Type     | Description          | Required |
+| ---------- | -------- | -------------------- | -------- |
+| `relation` | `string` | Relation to expand.  | yes      |
+| `object`   | `string` | Object to expand on. | yes      |
+
+**Response** `{ tree: string }`
+
+#### `POST /v1/admin/fga/reset`
+
+Delete the entire fine-grained authorization store (model, all versions, and all tuples) and start fresh. Refused if any tuples still exist. Destructive and audited.
+
+**Request body** — empty
+
+**Response** `{ message: string }`
 
 ## Errors
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -28,17 +28,19 @@ Then open `http://localhost:8080/app` for the built-in login UI.
 
 ## Ports: `EXPOSE`, publishing, and metrics {#docker-ports-exposure}
 
-The image **`EXPOSE`s `8080` and `8081`**. That only **documents** which ports the application may listen on; it does **not** open them on the Docker host. You choose what to publish with `-p` or Compose `ports:`.
+The image **`EXPOSE`s `8080`, `8081`, and `9091`**. That only **documents** which ports the application may listen on; it does **not** open them on the Docker host. You choose what to publish with `-p` or Compose `ports:`.
 
 | Port | Role | Typical use |
 |------|------|-------------|
 | **8080** | Main HTTP (API, UI, `/healthz`, `/readyz`) | **Yes** — map to the host or front with a reverse proxy / load balancer. |
 | **8081** | Prometheus **`/metrics`** (separate listener) | **Depends** — see below. |
+| **9091** | **gRPC** API (`AuthorizerService` + `AuthorizerAdminService`) | **Optional** — publish only if external gRPC clients connect; see [gRPC API](../core/grpc). |
 
 **Recommended defaults**
 
 - **`docker run` (single container, no in-Docker Prometheus):** publish **only `8080`** (e.g. `-p 8080:8080`). Metrics stay on **`127.0.0.1:8081`** inside the container; that is enough if you scrape from an agent on the **same host** using the container’s network namespace, or you do not need metrics yet.
 - **Docker Compose / Swarm with Prometheus as another service:** add **`--metrics-host=0.0.0.0`** so `8081` accepts connections on the **internal** compose network. Prefer **not** adding `"8081:8081"` under `ports:` (avoids exposing metrics on the host). Prometheus should use a service DNS name like `http://authorizer:8081/metrics` on the internal network only.
+- **gRPC clients:** the gRPC server binds to `--host` (default `0.0.0.0`) on **`9091`**. For server-to-server calls **on the same Docker/Compose network**, dial the service name (e.g. `authorizer:9091`) — no host publishing needed. Only add `-p 9091:9091` (or `"9091:9091"` under `ports:`) when a client **outside** Docker must reach it. gRPC is served as plaintext h2c by default — terminate TLS at an ingress/proxy (or set `--grpc-tls-cert` / `--grpc-tls-key`) before exposing it publicly.
 - **Public internet:** never publish **8081** to a public address. Keep metrics on loopback or an internal network; use auth/network policy at the edge if you must expose a scrape path.
 
 **Health checks:** the image `HEALTHCHECK` calls **`http://127.0.0.1:8080/healthz`** on the main server only, so liveness works even when metrics are loopback-only.

--- a/specs/2026-06-15-authorizer-admin-service-design.md
+++ b/specs/2026-06-15-authorizer-admin-service-design.md
@@ -1,0 +1,160 @@
+# AuthorizerAdminService — Design Spec
+
+**Date:** 2026-06-15
+**Status:** Approved (design)
+**Repo:** `authorizerdev/authorizer` (server) + `authorizerdev/authorizer-docs` (docs)
+
+## Goal
+
+Expose Authorizer's admin (super-admin-only) operations — the `_`-prefixed
+GraphQL queries and mutations — as a new gRPC service `AuthorizerAdminService`,
+with a REST surface via grpc-gateway, mirroring the multi-protocol pattern
+already shipped for the public `AuthorizerService` (PR #620).
+
+Business logic is migrated into the transport-agnostic `internal/service`
+package; GraphQL resolvers, the gRPC handler, and the REST gateway all become
+thin adapters over the same service methods (single source of truth).
+
+The admin service is served by the **same** `*grpc.Server` instance and the
+**same** grpc-gateway mux as the public service — one gRPC port and one REST
+port serve both surfaces. No separate admin server or port.
+
+## Scope
+
+All **active** `_`-prefixed GraphQL admin operations. The four deprecated
+admin operations (resolvers under `internal/graphql/_deprecated_*.go` that
+return `"deprecated"`) are **excluded**:
+
+- `_admin_signup` (admin secret is CLI-only in v2)
+- `_env`, `_update_env` (config is CLI flags in v2; replaced by `_admin_meta`)
+- `_generate_jwt_keys` (JWT keys are CLI flags in v2)
+
+That leaves **32 operations**.
+
+### Operations by domain group
+
+| Group | Ops | Count |
+|---|---|---|
+| Admin auth | `_admin_login`, `_admin_logout`, `_admin_session` | 3 |
+| Admin meta | `_admin_meta` | 1 |
+| Users | `_users`, `_user`, `_update_user`, `_delete_user`, `_verification_requests` | 5 |
+| Access | `_revoke_access`, `_enable_access`, `_invite_members` | 3 |
+| Webhooks | `_add_webhook`, `_update_webhook`, `_delete_webhook`, `_webhook`, `_webhooks`, `_webhook_logs`, `_test_endpoint` | 7 |
+| Email templates | `_add_email_template`, `_update_email_template`, `_delete_email_template`, `_email_templates` | 4 |
+| Audit | `_audit_logs` | 1 |
+| FGA admin | `_fga_write_model`, `_fga_write_tuples`, `_fga_delete_tuples`, `_fga_reset`, `_fga_get_model`, `_fga_read_tuples`, `_fga_list_users`, `_fga_expand` | 8 |
+
+**Total: 32**
+
+## Architecture
+
+Mirrors the public-API surface end to end.
+
+### 1. Proto (`proto/authorizer/v1/admin.proto`)
+
+- New file, package `authorizer.v1` (same package as `authorizer.proto`, so
+  it can reference existing messages: `User`, pagination, FGA types, etc.).
+- `service AuthorizerAdminService` with one RPC per op (32 RPCs).
+- Request/response messages reuse existing types from `authorizer.proto` /
+  `types.proto` / `common/v1` where they already exist; add admin-only
+  messages (e.g. `Webhook`, `EmailTemplate`, `AuditLog`, `Env`-less
+  `AdminMeta`, user-list pagination wrappers) as needed.
+- `protovalidate` rules mirror the GraphQL required fields.
+- REST annotations (`google.api.http`) under base path `/v1/admin/*`:
+  - **GET** for no-body reads: `_admin_session`, `_admin_meta`, `_fga_get_model`.
+  - **POST** for everything else (mutations and reads that take params,
+    matching the public convention where `check_permissions`/`list_permissions`
+    use POST).
+- Generated via `make proto-gen` (`buf generate`). The merged OpenAPI doc
+  picks up the admin service automatically.
+
+### 2. Service layer (`internal/service/admin_*.go`)
+
+- New files grouped by domain (e.g. `admin_users.go`, `admin_webhooks.go`,
+  `admin_email_templates.go`, `admin_access.go`, `admin_audit.go`,
+  `admin_meta.go`, `admin_auth.go`; FGA admin extends the existing `fga.go`).
+- A new `service.AdminProvider` interface declares the 32 methods. The
+  existing concrete `*provider` struct implements **both** `Provider` and
+  `AdminProvider` (one struct, two cohesive interfaces — keeps the public
+  `Provider` focused).
+- Each method signature follows the public pattern:
+  `Method(ctx, meta RequestMetadata, params *model.X) (*model.Y, *ResponseSideEffects, error)`.
+- Logic is migrated from the corresponding `internal/graphql` admin resolver.
+
+### 3. Admin authentication
+
+- Shared helper `requireSuperAdmin(meta RequestMetadata) error` builds the gin
+  shim (`gc := &gin.Context{Request: meta.Request}`) and calls
+  `TokenProvider.IsSuperAdmin(gc)`; returns a typed `Unauthenticated` service
+  error if false. Called at the top of every admin method except
+  `_admin_login` (which establishes the session).
+- `IsSuperAdmin` accepts either the admin session cookie or the
+  `x-authorizer-admin-secret` header (unless `--disable-admin-header-auth`).
+- `_admin_login` validates the admin secret (constant-time) and sets the admin
+  cookie via `ResponseSideEffects`; `_admin_logout` clears it. The gRPC handler
+  applies side-effects via `transport.ApplyToGRPC`; grpc-gateway promotes them
+  to `Set-Cookie` for REST.
+
+### 4. gRPC handler (`internal/grpcsrv/handlers/admin.go`)
+
+- New `AdminHandler{Service: service.AdminProvider}` embeds
+  `authorizerv1.UnimplementedAuthorizerAdminServiceServer`.
+- Each method delegates to the service, projects model → proto (reuse and
+  extend the projection helpers in `handlers/project.go`), and applies side
+  effects.
+- Registered on the **same** `*grpc.Server` in `internal/grpcsrv/server.go`
+  alongside `AuthorizerService`.
+
+### 5. REST gateway (`internal/gateway/mount.go`)
+
+- Add `RegisterAuthorizerAdminServiceHandler` to `registerAll`.
+- Add `runtime.WithIncomingHeaderMatcher` so the custom
+  `x-authorizer-admin-secret` header is forwarded to the gRPC layer (the
+  default matcher only forwards permanent headers such as `Authorization` and
+  `Cookie`). The matcher falls back to `runtime.DefaultHeaderMatcher` for all
+  other headers so existing behavior is unchanged.
+- Extend `transport.MetaFromGRPC` / `synthRequest` to copy
+  `x-authorizer-admin-secret` from incoming metadata onto the synthesized
+  `*http.Request` so `IsSuperAdmin` sees it over REST.
+
+### 6. GraphQL resolvers (`internal/graphql/*.go`)
+
+- Refactor the 32 active admin resolvers into thin delegating adapters over
+  `ServiceProvider` (the `meta.go` pattern), so logic lives only in
+  `internal/service`. Deprecated resolvers are left untouched.
+
+## Testing
+
+- Per-op coverage following existing conventions (integration tests under
+  `internal/integration_tests/`, service unit tests where the public ops have
+  them).
+- Extend `internal/e2e/smoke_test.go`: after admin login, exercise
+  representative admin ops over **REST and gRPC** (`_admin_meta`, `_users`
+  list, a webhook read), plus a **fail-closed** check (missing/invalid admin
+  secret → `401` / `Unauthenticated`).
+- `make proto-lint` and `make proto-breaking` must pass (admin.proto is
+  additive — no breaking change to the public service).
+
+## Documentation (`authorizer-docs`)
+
+Update the three API reference pages under `docs/core/`:
+
+- `graphql-api.md`, `rest-api.md`, `grpc.md`.
+- Add the admin operations to each page.
+- Split each page's Table of Contents into two sections:
+  **Public APIs** and **Authorizer Admin APIs**.
+
+## Delivery
+
+Single feature branch / PR. The implementation plan checkpoints by domain
+group (auth → meta → users → access → webhooks → email-templates → audit →
+fga) so work is resumable if interrupted. Order: proto first (one group at a
+time), then service + handler + resolver refactor + tests per group, then
+gateway wiring, then smoke test, then docs.
+
+## Non-goals
+
+- No MCP exposure of admin operations (admin surface stays off MCP).
+- No changes to admin auth semantics (same admin secret / cookie / header).
+- No new admin operations beyond the existing GraphQL surface.
+- Deprecated admin operations are not ported.

--- a/specs/2026-06-15-authorizer-admin-service-plan.md
+++ b/specs/2026-06-15-authorizer-admin-service-plan.md
@@ -379,6 +379,25 @@ git commit -m "chore(admin-api): wire admin gateway + forward admin-secret heade
 
 ---
 
+## Proto conventions (MUST follow — verified against existing `authorizer.proto`)
+
+- **No shared `Response` message.** Ops that return `model.Response{Message}`
+  use an inline field: `message XResponse { string message = 1; }` (see
+  `LogoutResponse`/`RevokeResponse`). Wherever this plan writes
+  `Response response = 1;` or `message Response {...}`, substitute the inline
+  `string message = 1;` form.
+- **Pagination:** request side uses `authorizer.common.v1.PaginationRequest`;
+  response side embeds `authorizer.common.v1.Pagination pagination = N;`.
+  Import `authorizer/common/v1/pagination.proto`. The `Pagination` field name
+  in this plan maps to these common types.
+- **Optional scalars:** plain proto3 scalars (no `optional` keyword);
+  handlers collapse empty→nil via the existing `optionalString` helper, matching
+  the public surface.
+- **Reuse `User`** from `authorizer/v1/types.proto` (already imported).
+- **Always confirm field-for-field parity** with the referenced
+  `internal/graph/model` type in `internal/graph/model/models_gen.go` before
+  generating each message.
+
 ## Per-op pattern (CANONICAL — applies to every op in Phases 1–8)
 
 Each operation is implemented with these five units. Phase 1, Task 1.1 shows
@@ -427,18 +446,12 @@ message AdminMetaResponse {
   AdminMeta admin_meta = 1;
 }
 message AdminMeta {
-  // mirror every field of model.AdminMeta (e.g. version, configured roles,
-  // default roles, protected roles). Use string/bool/repeated string to match
-  // the model. EmitUnpopulated keeps zero values visible to REST.
-  string version = 1;
-  repeated string roles = 2;
-  repeated string default_roles = 3;
-  repeated string protected_roles = 4;
+  // model.AdminMeta has exactly these three fields (no version).
+  repeated string roles = 1;
+  repeated string default_roles = 2;
+  repeated string protected_roles = 3;
 }
 ```
-
-> Inspect `internal/graph/model` AdminMeta to confirm exact fields and adjust
-> the message fields 1:1 before generating.
 
 - [ ] **Step 2: Generate**
 
@@ -501,7 +514,6 @@ func projectAdminMeta(m *model.AdminMeta) *authorizerv1.AdminMeta {
 		return nil
 	}
 	return &authorizerv1.AdminMeta{
-		Version:        m.Version,
 		Roles:          m.Roles,
 		DefaultRoles:   m.DefaultRoles,
 		ProtectedRoles: m.ProtectedRoles,

--- a/specs/2026-06-15-authorizer-admin-service-plan.md
+++ b/specs/2026-06-15-authorizer-admin-service-plan.md
@@ -1,0 +1,792 @@
+# AuthorizerAdminService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the 32 active `_`-prefixed admin GraphQL operations as a gRPC `AuthorizerAdminService` + REST surface, with logic migrated into `internal/service`, served by the same gRPC server and gateway as the public API.
+
+**Architecture:** Mirror the public `AuthorizerService` pattern (PR #620). Logic lives in transport-agnostic `internal/service` (new `AdminProvider` interface, implemented by the existing `*provider`). GraphQL resolvers, the new gRPC `AdminHandler`, and grpc-gateway REST all delegate to it. New proto file `proto/authorizer/v1/admin.proto` in package `authorizer.v1`. Admin auth via shared `requireSuperAdmin(meta)`.
+
+**Tech Stack:** Go 1.24, buf/protovalidate, grpc-gateway v2, gqlgen, gin shim, zerolog. Reference design: `specs/2026-06-15-authorizer-admin-service-design.md`.
+
+---
+
+## Conventions used throughout this plan
+
+- **Branch:** all work on `feat/authorizer-admin-api` in the server repo. Never commit to main.
+- **Proto regen:** after editing any `.proto`, run `make proto-gen` (runs `buf generate`). Generated code lands under `gen/go/...` — never hand-edit it.
+- **Build check:** `go build ./...` after every Go change.
+- **Single-op integration test run:**
+  `go clean --testcache && TEST_DBS="sqlite" go test -p 1 -v -run TestAdmin<Name> ./internal/integration_tests/`
+- **Smoke test run:** `go test -v -run TestReleaseSmoke ./internal/e2e/`
+- **Proto lint/breaking:** `make proto-lint && make proto-breaking`.
+- **Commit cadence:** one commit per task (per op or per scaffolding unit). Commit messages: `feat(admin-api): <op>` / `chore(admin-api): <scaffolding>`.
+
+## File structure
+
+**Create:**
+- `proto/authorizer/v1/admin.proto` — `AuthorizerAdminService` + admin messages.
+- `internal/grpcsrv/handlers/admin.go` — `AdminHandler`, delegates to `service.AdminProvider`.
+- `internal/grpcsrv/handlers/admin_project.go` — proto↔model projections for admin types (Webhook, EmailTemplate, AuditLog, AdminMeta, lists).
+- `internal/service/admin_provider.go` — `AdminProvider` interface + `requireSuperAdmin` helper.
+- `internal/service/admin_auth.go` — AdminLogin/Logout/Session/Meta.
+- `internal/service/admin_users.go` — Users/User/UpdateUser/DeleteUser/VerificationRequests.
+- `internal/service/admin_access.go` — RevokeAccess/EnableAccess/InviteMembers.
+- `internal/service/admin_webhooks.go` — webhook ops + TestEndpoint + WebhookLogs.
+- `internal/service/admin_email_templates.go` — email-template ops.
+- `internal/service/admin_audit.go` — AuditLogs.
+- `internal/service/admin_fga.go` — FGA admin ops (or extend existing `fga.go`).
+- `internal/integration_tests/admin_grpc_test.go` — admin gRPC/REST integration tests.
+
+**Modify:**
+- `internal/grpcsrv/server.go` — register `AuthorizerAdminService` on the same `*grpc.Server`.
+- `internal/gateway/mount.go` — register admin gateway handler in `registerAll`; add `WithIncomingHeaderMatcher`.
+- `internal/grpcsrv/transport/grpc_metadata.go` — carry `x-authorizer-admin-secret` onto `synthRequest`.
+- `internal/service/provider.go` — assert `*provider` implements `AdminProvider`.
+- The 32 admin resolvers under `internal/graphql/*.go` — refactor to thin adapters.
+- `internal/e2e/smoke_test.go` — admin REST + gRPC + fail-closed coverage.
+
+---
+
+## Phase 0 — Scaffolding
+
+### Task 0.1: Branch + empty admin.proto compiles
+
+**Files:**
+- Create: `proto/authorizer/v1/admin.proto`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /Users/lakhansamani/personal/authorizer/authorizer
+git checkout main && git pull --ff-only
+git checkout -b feat/authorizer-admin-api
+```
+
+- [ ] **Step 2: Create the proto skeleton**
+
+```proto
+// proto/authorizer/v1/admin.proto
+//
+// AuthorizerAdminService exposes Authorizer's super-admin-only operations
+// (the `_`-prefixed GraphQL queries/mutations). It is registered on the SAME
+// grpc.Server and gateway mux as AuthorizerService. Every RPC requires
+// super-admin auth (admin session cookie or x-authorizer-admin-secret header)
+// except AdminLogin, which establishes it. Admin operations are intentionally
+// NOT exposed over MCP.
+syntax = "proto3";
+
+package authorizer.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "authorizer/v1/types.proto";
+import "authorizer/v1/authorizer.proto";
+
+service AuthorizerAdminService {
+}
+```
+
+- [ ] **Step 3: Generate + build**
+
+Run: `make proto-gen && go build ./...`
+Expected: PASS (no service methods yet; empty service is valid).
+
+- [ ] **Step 4: Lint**
+
+Run: `make proto-lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add proto/authorizer/v1/admin.proto gen/
+git commit -m "chore(admin-api): scaffold AuthorizerAdminService proto"
+```
+
+### Task 0.2: AdminProvider interface + requireSuperAdmin helper
+
+**Files:**
+- Create: `internal/service/admin_provider.go`
+- Modify: `internal/service/provider.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/service/admin_provider_test.go
+package service
+
+import "testing"
+
+// Compile-time guarantee that *provider satisfies AdminProvider.
+func TestProviderImplementsAdminProvider(t *testing.T) {
+	var _ AdminProvider = (*provider)(nil)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/service/ -run TestProviderImplementsAdminProvider`
+Expected: FAIL — `AdminProvider` undefined.
+
+- [ ] **Step 3: Define the interface + helper**
+
+```go
+// internal/service/admin_provider.go
+package service
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+)
+
+// AdminProvider is the transport-agnostic API for Authorizer's super-admin
+// operations. The same concrete *provider that implements Provider also
+// implements AdminProvider; the interface is split to keep the public
+// Provider focused. Each method requires super-admin auth (enforced via
+// requireSuperAdmin) except AdminLogin.
+type AdminProvider interface {
+	// Auth + meta.
+	AdminLogin(ctx context.Context, meta RequestMetadata, params *model.AdminLoginRequest) (*model.Response, *ResponseSideEffects, error)
+	AdminLogout(ctx context.Context, meta RequestMetadata) (*model.Response, *ResponseSideEffects, error)
+	AdminSession(ctx context.Context, meta RequestMetadata) (*model.Response, *ResponseSideEffects, error)
+	AdminMeta(ctx context.Context, meta RequestMetadata) (*model.AdminMeta, *ResponseSideEffects, error)
+	// Users.
+	Users(ctx context.Context, meta RequestMetadata, params *model.PaginatedRequest) (*model.Users, *ResponseSideEffects, error)
+	User(ctx context.Context, meta RequestMetadata, params *model.GetUserRequest) (*model.User, *ResponseSideEffects, error)
+	UpdateUser(ctx context.Context, meta RequestMetadata, params *model.UpdateUserRequest) (*model.User, *ResponseSideEffects, error)
+	DeleteUser(ctx context.Context, meta RequestMetadata, params *model.DeleteUserRequest) (*model.Response, *ResponseSideEffects, error)
+	VerificationRequests(ctx context.Context, meta RequestMetadata, params *model.PaginatedRequest) (*model.VerificationRequests, *ResponseSideEffects, error)
+	// Access.
+	RevokeAccess(ctx context.Context, meta RequestMetadata, params *model.UpdateAccessRequest) (*model.Response, *ResponseSideEffects, error)
+	EnableAccess(ctx context.Context, meta RequestMetadata, params *model.UpdateAccessRequest) (*model.Response, *ResponseSideEffects, error)
+	InviteMembers(ctx context.Context, meta RequestMetadata, params *model.InviteMemberRequest) (*model.InviteMembersResponse, *ResponseSideEffects, error)
+	// Webhooks.
+	AddWebhook(ctx context.Context, meta RequestMetadata, params *model.AddWebhookRequest) (*model.Response, *ResponseSideEffects, error)
+	UpdateWebhook(ctx context.Context, meta RequestMetadata, params *model.UpdateWebhookRequest) (*model.Response, *ResponseSideEffects, error)
+	DeleteWebhook(ctx context.Context, meta RequestMetadata, params *model.WebhookRequest) (*model.Response, *ResponseSideEffects, error)
+	Webhook(ctx context.Context, meta RequestMetadata, params *model.WebhookRequest) (*model.Webhook, *ResponseSideEffects, error)
+	Webhooks(ctx context.Context, meta RequestMetadata, params *model.PaginatedRequest) (*model.Webhooks, *ResponseSideEffects, error)
+	WebhookLogs(ctx context.Context, meta RequestMetadata, params *model.ListWebhookLogRequest) (*model.WebhookLogs, *ResponseSideEffects, error)
+	TestEndpoint(ctx context.Context, meta RequestMetadata, params *model.TestEndpointRequest) (*model.TestEndpointResponse, *ResponseSideEffects, error)
+	// Email templates.
+	AddEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.AddEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
+	UpdateEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.UpdateEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
+	DeleteEmailTemplate(ctx context.Context, meta RequestMetadata, params *model.DeleteEmailTemplateRequest) (*model.Response, *ResponseSideEffects, error)
+	EmailTemplates(ctx context.Context, meta RequestMetadata, params *model.PaginatedRequest) (*model.EmailTemplates, *ResponseSideEffects, error)
+	// Audit.
+	AuditLogs(ctx context.Context, meta RequestMetadata, params *model.ListAuditLogRequest) (*model.AuditLogs, *ResponseSideEffects, error)
+	// FGA admin.
+	FgaWriteModel(ctx context.Context, meta RequestMetadata, params *model.FgaWriteModelInput) (*model.FgaModel, *ResponseSideEffects, error)
+	FgaWriteTuples(ctx context.Context, meta RequestMetadata, params *model.FgaWriteTuplesInput) (*model.Response, *ResponseSideEffects, error)
+	FgaDeleteTuples(ctx context.Context, meta RequestMetadata, params *model.FgaWriteTuplesInput) (*model.Response, *ResponseSideEffects, error)
+	FgaReset(ctx context.Context, meta RequestMetadata) (*model.Response, *ResponseSideEffects, error)
+	FgaGetModel(ctx context.Context, meta RequestMetadata) (*model.FgaModel, *ResponseSideEffects, error)
+	FgaReadTuples(ctx context.Context, meta RequestMetadata, params *model.FgaReadTuplesInput) (*model.FgaTuples, *ResponseSideEffects, error)
+	FgaListUsers(ctx context.Context, meta RequestMetadata, params *model.FgaListUsersInput) (*model.FgaListUsersResponse, *ResponseSideEffects, error)
+	FgaExpand(ctx context.Context, meta RequestMetadata, params *model.FgaExpandInput) (*model.FgaExpandResponse, *ResponseSideEffects, error)
+}
+
+// requireSuperAdmin enforces super-admin auth in the transport-agnostic layer.
+// It reuses the existing gin-shim pattern (meta.Request carries headers +
+// cookies synthesized by transport.MetaFromGRPC / service.MetaFromGin) so the
+// same TokenProvider.IsSuperAdmin check runs identically over GraphQL, gRPC,
+// and REST. Returns ErrUnauthorized (mapped to codes.Unauthenticated) if the
+// caller is not a super admin.
+func (p *provider) requireSuperAdmin(meta RequestMetadata) error {
+	gc := &gin.Context{Request: meta.Request}
+	if !p.TokenProvider.IsSuperAdmin(gc) {
+		return ErrUnauthorized
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Add ErrUnauthorized if missing**
+
+Check `internal/service/errors.go` for an unauthorized sentinel. If none maps to `codes.Unauthenticated`, add:
+
+```go
+// ErrUnauthorized indicates the caller failed authentication (no/invalid
+// admin credentials). Mapped to codes.Unauthenticated by the gRPC ErrorMap
+// interceptor and to HTTP 401 by the REST gateway.
+var ErrUnauthorized = NewError(ErrCodeUnauthorized, "unauthorized")
+```
+
+Verify the error code → gRPC status mapping in `internal/grpcsrv/interceptors/errormap.go` covers it (Unauthenticated → 401). Add the mapping if absent.
+
+- [ ] **Step 5: Build**
+
+Run: `go build ./...`
+Expected: FAIL — interface methods not yet implemented on `*provider`. This is expected; the compile-time assertion test will pass only after the methods land. Temporarily comment out the assertion test body until Phase 1+ methods exist, OR keep the test and let it gate the final phase.
+
+> NOTE: To keep the tree compiling during the staged migration, do NOT add the
+> `var _ AdminProvider = (*provider)(nil)` assertion to `provider.go` until ALL
+> methods are implemented (end of Phase 8). Keep the assertion test file but
+> guard it with a build tag `//go:build adminprovider_complete` until then.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/admin_provider.go internal/service/admin_provider_test.go internal/service/errors.go
+git commit -m "chore(admin-api): define AdminProvider interface + requireSuperAdmin"
+```
+
+### Task 0.3: AdminHandler skeleton (registered, all Unimplemented)
+
+**Files:**
+- Create: `internal/grpcsrv/handlers/admin.go`
+- Modify: `internal/grpcsrv/server.go`
+
+- [ ] **Step 1: Create the handler skeleton**
+
+```go
+// internal/grpcsrv/handlers/admin.go
+//
+// AdminHandler implements authorizer.v1.AuthorizerAdminService. It embeds the
+// generated UnimplementedAuthorizerAdminServiceServer so any not-yet-migrated
+// RPC returns codes.Unimplemented. Methods are filled in one domain group at a
+// time, each delegating to service.AdminProvider following the public
+// AuthorizerHandler pattern.
+package handlers
+
+import (
+	authorizerv1 "github.com/authorizerdev/authorizer/gen/go/authorizer/v1"
+	"github.com/authorizerdev/authorizer/internal/service"
+)
+
+// AdminHandler serves the admin gRPC/REST surface.
+type AdminHandler struct {
+	authorizerv1.UnimplementedAuthorizerAdminServiceServer
+	Service service.AdminProvider
+}
+```
+
+- [ ] **Step 2: Register on the same gRPC server**
+
+In `internal/grpcsrv/server.go`, after the existing `RegisterAuthorizerServiceServer` line, add:
+
+```go
+	// Admin surface on the SAME server. AdminHandler embeds
+	// UnimplementedAuthorizerAdminServiceServer; migrated RPCs override the
+	// stubs. deps.ServiceProvider satisfies both Provider and AdminProvider.
+	authorizerv1.RegisterAuthorizerAdminServiceServer(srv, &handlers.AdminHandler{Service: deps.ServiceProvider})
+```
+
+Note: `deps.ServiceProvider` is typed `service.Provider`. Change `Dependencies.ServiceProvider` to a type that satisfies both, or pass the concrete provider. Simplest: keep the field as `service.Provider` and add `AdminProvider` to the same value via a second field, OR widen the field. Recommended: change `server.Dependencies.ServiceProvider` to an interface embedding both:
+
+```go
+// in server.go Dependencies
+ServiceProvider interface {
+	service.Provider
+	service.AdminProvider
+}
+```
+
+Confirm the value wired in `cmd/root.go` (the concrete `*service.provider` via `service.New(...)`) satisfies both. (It will once Phase 8 completes; until then the build needs all methods — so register the admin server but keep the field as `service.Provider` and type-assert inside, OR defer this registration line until Phase 1 lands at least the stubs. Recommended: do registration here but only after Task 0.2's methods compile. Since methods aren't implemented yet, gate by implementing a no-op `*provider` set first — see Step 3.)
+
+- [ ] **Step 3: Make it compile now (stub methods)**
+
+To keep main compiling before per-op work, the `UnimplementedAuthorizerAdminServiceServer` embed already provides all RPC stubs for the HANDLER. The blocker is `*service.provider` not yet implementing `AdminProvider`. Resolve by widening the handler field to the concrete need only when methods exist. For Phase 0, set `AdminHandler.Service` to `service.AdminProvider` but wire it in `server.go` using the same `deps.ServiceProvider` value and keep `Dependencies.ServiceProvider service.Provider`; cast with a runtime assertion:
+
+```go
+	adminSvc, _ := deps.ServiceProvider.(service.AdminProvider)
+	authorizerv1.RegisterAuthorizerAdminServiceServer(srv, &handlers.AdminHandler{Service: adminSvc})
+```
+
+This compiles immediately (interface assertion), and `adminSvc` becomes non-nil once `*provider` implements all methods. RPCs invoked before then hit the Unimplemented stub.
+
+- [ ] **Step 4: Build + commit**
+
+Run: `make proto-gen && go build ./...`
+Expected: PASS.
+
+```bash
+git add internal/grpcsrv/handlers/admin.go internal/grpcsrv/server.go
+git commit -m "chore(admin-api): register AdminHandler on shared gRPC server"
+```
+
+### Task 0.4: Gateway wiring + admin-secret header forwarding
+
+**Files:**
+- Modify: `internal/gateway/mount.go`, `internal/grpcsrv/transport/grpc_metadata.go`
+
+- [ ] **Step 1: Register admin gateway handler**
+
+In `registerAll` (`internal/gateway/mount.go`), add after the existing registrar:
+
+```go
+	if err := authorizerv1.RegisterAuthorizerAdminServiceHandler(ctx, mux, conn); err != nil {
+		return err
+	}
+	return nil
+```
+
+(Convert the existing single `return` into the two-registrar form.)
+
+- [ ] **Step 2: Forward the custom admin-secret header**
+
+In the `runtime.NewServeMux(...)` options in `mount.go`, add:
+
+```go
+		// Forward the custom admin-secret header to the gRPC layer. The
+		// default matcher only forwards permanent headers (Authorization,
+		// Cookie); admin header-auth needs x-authorizer-admin-secret too.
+		runtime.WithIncomingHeaderMatcher(func(key string) (string, bool) {
+			if strings.EqualFold(key, "x-authorizer-admin-secret") {
+				return key, true
+			}
+			return runtime.DefaultHeaderMatcher(key)
+		}),
+```
+
+Add `"strings"` to imports.
+
+- [ ] **Step 3: Carry admin-secret onto the synth request**
+
+In `internal/grpcsrv/transport/grpc_metadata.go`, in `MetaFromGRPC`, after building `meta` and before `synthRequest`, capture the header; and in `synthRequest`, set it on the request. Add a field to `RequestMetadata` if a generic header map isn't present:
+
+```go
+	// in MetaFromGRPC, extend meta:
+	meta.AdminSecret = firstHeader(md, "x-authorizer-admin-secret", "grpcgateway-x-authorizer-admin-secret")
+```
+
+```go
+	// in synthRequest:
+	if meta.AdminSecret != "" {
+		req.Header.Set("x-authorizer-admin-secret", meta.AdminSecret)
+	}
+```
+
+Add `AdminSecret string` to the `service.RequestMetadata` struct (in `internal/service/sideeffects.go`) and populate it in `MetaFromGin` too:
+
+```go
+	// in MetaFromGin:
+	AdminSecret: gc.GetHeader("x-authorizer-admin-secret"),
+```
+
+- [ ] **Step 4: Build + commit**
+
+Run: `go build ./...`
+Expected: PASS.
+
+```bash
+git add internal/gateway/mount.go internal/grpcsrv/transport/grpc_metadata.go internal/service/sideeffects.go
+git commit -m "chore(admin-api): wire admin gateway + forward admin-secret header"
+```
+
+---
+
+## Per-op pattern (CANONICAL — applies to every op in Phases 1–8)
+
+Each operation is implemented with these five units. Phase 1, Task 1.1 shows
+the FULL code for `AdminMeta` as the reference. Every later op repeats this
+exact structure; its task lists only the concrete deltas (proto RPC + messages,
+service method body source, projection notes, REST path/verb).
+
+1. **Proto** — add the RPC to `AuthorizerAdminService` + request/response
+   messages to `admin.proto`. REST annotation under `/v1/admin/...`. Run
+   `make proto-gen`.
+2. **Service method** — implement on `*provider` in the relevant
+   `internal/service/admin_*.go` file. First line (except AdminLogin):
+   `if err := p.requireSuperAdmin(meta); err != nil { return nil, nil, err }`.
+   Body migrated verbatim from the GraphQL resolver, replacing
+   `utils.GinContextFromContext(ctx)` usage with `meta`/the gin shim.
+3. **Resolver refactor** — replace the body in `internal/graphql/<op>.go` with
+   a thin delegation: `res, _, err := g.ServiceProvider.<Method>(ctx, service.MetaFromGin(gc), params); return res, err`.
+4. **gRPC handler method** — in `admin.go`, delegate to `h.Service.<Method>`,
+   project model→proto, apply side effects.
+5. **Test** — integration test exercising the op over gRPC + REST (and a
+   fail-closed case for auth-gated reads/mutations).
+
+---
+
+## Phase 1 — Admin auth + meta (4 ops)
+
+### Task 1.1: `_admin_meta` (CANONICAL — full code)
+
+**Files:**
+- Modify: `proto/authorizer/v1/admin.proto`, `internal/grpcsrv/handlers/admin.go`, `internal/grpcsrv/handlers/admin_project.go` (create), `internal/graphql/admin_meta.go`
+- Create: `internal/service/admin_auth.go`, `internal/integration_tests/admin_grpc_test.go`
+
+- [ ] **Step 1: Add proto RPC + messages**
+
+```proto
+// in service AuthorizerAdminService:
+  // AdminMeta returns admin-only configuration metadata (configured roles,
+  // etc.). Requires super-admin auth.
+  rpc AdminMeta(AdminMetaRequest) returns (AdminMetaResponse) {
+    option (google.api.http) = {get: "/v1/admin/meta"};
+  }
+
+// messages (mirror fields of model.AdminMeta in internal/graph/model):
+message AdminMetaRequest {}
+message AdminMetaResponse {
+  AdminMeta admin_meta = 1;
+}
+message AdminMeta {
+  // mirror every field of model.AdminMeta (e.g. version, configured roles,
+  // default roles, protected roles). Use string/bool/repeated string to match
+  // the model. EmitUnpopulated keeps zero values visible to REST.
+  string version = 1;
+  repeated string roles = 2;
+  repeated string default_roles = 3;
+  repeated string protected_roles = 4;
+}
+```
+
+> Inspect `internal/graph/model` AdminMeta to confirm exact fields and adjust
+> the message fields 1:1 before generating.
+
+- [ ] **Step 2: Generate**
+
+Run: `make proto-gen && make proto-lint`
+Expected: PASS.
+
+- [ ] **Step 3: Service method**
+
+```go
+// internal/service/admin_auth.go
+package service
+
+import (
+	"context"
+
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+)
+
+// AdminMeta returns admin-only configuration metadata. Requires super admin.
+// Logic migrated from internal/graphql/admin_meta.go.
+func (p *provider) AdminMeta(ctx context.Context, meta RequestMetadata) (*model.AdminMeta, *ResponseSideEffects, error) {
+	if err := p.requireSuperAdmin(meta); err != nil {
+		return nil, nil, err
+	}
+	// <body migrated from graphqlProvider.AdminMeta — build *model.AdminMeta
+	// from p.Config; no gin.Context needed beyond the auth check>
+	res := &model.AdminMeta{ /* fields from p.Config, per original resolver */ }
+	return res, nil, nil
+}
+```
+
+> Open `internal/graphql/admin_meta.go` and copy its construction logic into
+> the body, dropping the inline `IsSuperAdmin` check (now handled by
+> requireSuperAdmin).
+
+- [ ] **Step 4: Resolver refactor**
+
+```go
+// internal/graphql/admin_meta.go
+func (g *graphqlProvider) AdminMeta(ctx context.Context) (*model.AdminMeta, error) {
+	gc, _ := utils.GinContextFromContext(ctx)
+	res, _, err := g.ServiceProvider.AdminMeta(ctx, service.MetaFromGin(gc))
+	return res, err
+}
+```
+
+- [ ] **Step 5: Projection + handler**
+
+```go
+// internal/grpcsrv/handlers/admin_project.go
+package handlers
+
+import (
+	"github.com/authorizerdev/authorizer/internal/graph/model"
+	authorizerv1 "github.com/authorizerdev/authorizer/gen/go/authorizer/v1"
+)
+
+func projectAdminMeta(m *model.AdminMeta) *authorizerv1.AdminMeta {
+	if m == nil {
+		return nil
+	}
+	return &authorizerv1.AdminMeta{
+		Version:        m.Version,
+		Roles:          m.Roles,
+		DefaultRoles:   m.DefaultRoles,
+		ProtectedRoles: m.ProtectedRoles,
+	}
+}
+```
+
+```go
+// internal/grpcsrv/handlers/admin.go
+func (h *AdminHandler) AdminMeta(ctx context.Context, _ *authorizerv1.AdminMetaRequest) (*authorizerv1.AdminMetaResponse, error) {
+	res, _, err := h.Service.AdminMeta(ctx, transport.MetaFromGRPC(ctx))
+	if err != nil {
+		return nil, err
+	}
+	return &authorizerv1.AdminMetaResponse{AdminMeta: projectAdminMeta(res)}, nil
+}
+```
+
+Add imports: `context`, `transport`, `authorizerv1`.
+
+- [ ] **Step 6: Integration test**
+
+```go
+// internal/integration_tests/admin_grpc_test.go — follow grpc_surface_test.go
+// patterns for spinning the server + dialing. Assert:
+//   - GET /v1/admin/meta WITHOUT admin secret -> 401
+//   - GET /v1/admin/meta WITH x-authorizer-admin-secret header -> 200 + roles
+//   - gRPC AdminMeta with admin-secret metadata -> roles
+func TestAdminMeta(t *testing.T) { /* ... */ }
+```
+
+- [ ] **Step 7: Verify + commit**
+
+Run: `make proto-gen && go build ./... && go clean --testcache && TEST_DBS="sqlite" go test -p 1 -v -run TestAdminMeta ./internal/integration_tests/`
+Expected: PASS.
+
+```bash
+git add -A && git commit -m "feat(admin-api): _admin_meta over gRPC + REST"
+```
+
+### Task 1.2: `_admin_login`
+
+Deltas from canonical:
+- **Proto:** `rpc AdminLogin(AdminLoginRequest) returns (AdminLoginResponse) { option (google.api.http) = {post: "/v1/admin/login" body: "*"}; }`. `AdminLoginRequest { string admin_secret = 1 [(buf.validate.field).required = true]; }`. `AdminLoginResponse { Response response = 1; }` (reuse existing `Response` message; if none, add `message Response { string message = 1; }`).
+- **Service:** `AdminLogin(ctx, meta, *model.AdminLoginRequest) (*model.Response, *ResponseSideEffects, error)` in `admin_auth.go`. **No** `requireSuperAdmin` (this establishes auth). Migrate body from `internal/graphql/admin_login.go`: constant-time compare against `p.Config.AdminSecret`, audit events via `p.AuditProvider`, metrics. Instead of `cookie.SetAdminCookie(gc, ...)`, return the cookie in `ResponseSideEffects` (build the admin cookie and append to `side.Cookies`). Inspect `cookie.SetAdminCookie` to replicate cookie name/attrs into a `*http.Cookie`.
+- **Resolver refactor:** delegate; apply side effects via `service.ApplyToGin(gc, side)`.
+- **Handler:** delegate; `transport.ApplyToGRPC(ctx, side)` then return.
+- **Test:** valid secret → 200 + Set-Cookie; invalid secret → 401.
+
+### Task 1.3: `_admin_logout`
+
+Deltas:
+- **Proto:** `rpc AdminLogout(AdminLogoutRequest) returns (AdminLogoutResponse) { option (google.api.http) = {post: "/v1/admin/logout"}; }`. `AdminLogoutRequest {}`, `AdminLogoutResponse { Response response = 1; }`.
+- **Service:** `AdminLogout(ctx, meta) (*model.Response, *ResponseSideEffects, error)`; call `requireSuperAdmin`; migrate from `admin_logout.go`; clear admin cookie via side effects (deleted cookie).
+- **Resolver/handler/test:** canonical. Test: logged-in → 200 + cookie cleared; no auth → 401.
+
+### Task 1.4: `_admin_session`
+
+Deltas:
+- **Proto:** `rpc AdminSession(AdminSessionRequest) returns (AdminSessionResponse) { option (google.api.http) = {get: "/v1/admin/session"}; }`. `AdminSessionRequest {}`, `AdminSessionResponse { Response response = 1; }`.
+- **Service:** `AdminSession(ctx, meta) (*model.Response, *ResponseSideEffects, error)`; `requireSuperAdmin`; migrate from `admin_session.go`.
+- **Resolver/handler/test:** canonical. Test: with admin secret → 200; without → 401.
+
+**Phase 1 gate:** `go build ./... && TEST_DBS="sqlite" go test -p 1 -run 'TestAdmin(Meta|Login|Logout|Session)' ./internal/integration_tests/`
+
+---
+
+## Phase 2 — Users (5 ops)
+
+For each: canonical pattern. `requireSuperAdmin` first. Migrate body from the
+named resolver. Reuse the existing proto `User` message for user payloads; add
+list-wrapper + pagination messages mirroring the models.
+
+### Task 2.1: `_users`
+- **Proto:** `rpc Users(AdminUsersRequest) returns (AdminUsersResponse) { option = {post: "/v1/admin/users" body: "*"}; }`. `AdminUsersRequest { Pagination pagination = 1; }` (reuse `model.PaginatedRequest` shape; reuse common pagination message if present). `AdminUsersResponse { repeated User users = 1; Pagination pagination = 2; }` mirroring `model.Users`.
+- **Service:** `Users(ctx, meta, *model.PaginatedRequest) (*model.Users, ...)` in `admin_users.go`, body from `users.go`.
+- **Projection:** `projectUsers(*model.Users)` reusing existing `projectUser` + a pagination projection.
+- **Test:** list with admin secret → users; without → 401.
+
+### Task 2.2: `_user`
+- **Proto:** `rpc User(AdminUserRequest) returns (AdminUserResponse) { option = {post: "/v1/admin/user" body: "*"}; }`. `AdminUserRequest { string id = 1; string email = 2; }` (mirror `model.GetUserRequest`). `AdminUserResponse { User user = 1; }`.
+- **Service:** `User(ctx, meta, *model.GetUserRequest)`, body from `user.go`. Projection: existing `projectUser`.
+
+### Task 2.3: `_update_user`
+- **Proto:** `rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) { option = {post: "/v1/admin/update_user" body: "*"}; }`. `UpdateUserRequest` mirroring `model.UpdateUserRequest` (id required + optional profile/role/scoped fields; use proto3 optional or wrappers per existing convention in authorizer.proto). `UpdateUserResponse { User user = 1; }`.
+- **Service:** body from `update_user.go`. Projection: `projectUser`.
+
+### Task 2.4: `_delete_user`
+- **Proto:** `rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) { option = {post: "/v1/admin/delete_user" body: "*"}; }`. `DeleteUserRequest { string email = 1 [(buf.validate.field).required = true]; }`. `DeleteUserResponse { Response response = 1; }`.
+- **Service:** body from `delete_user.go`.
+
+### Task 2.5: `_verification_requests`
+- **Proto:** `rpc VerificationRequests(VerificationRequestsRequest) returns (VerificationRequestsResponse) { option = {post: "/v1/admin/verification_requests" body: "*"}; }`. Request `{ Pagination pagination = 1; }`. Response mirroring `model.VerificationRequests` (`repeated VerificationRequest verification_requests = 1; Pagination pagination = 2;`); add `VerificationRequest` message mirroring `model.VerificationRequest`.
+- **Service:** body from `verification_requests.go`. Add `projectVerificationRequests`.
+
+**Phase 2 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminUser' ./internal/integration_tests/`
+
+---
+
+## Phase 3 — Access (3 ops)
+
+### Task 3.1: `_revoke_access`
+- **Proto:** `rpc RevokeAccess(UpdateAccessRequest) returns (UpdateAccessResponse) { option = {post: "/v1/admin/revoke_access" body: "*"}; }`. `UpdateAccessRequest { string user_id = 1 [(buf.validate.field).required = true]; }` (mirror `model.UpdateAccessRequest`). `UpdateAccessResponse { Response response = 1; }`.
+- **Service:** body from `revoke_access.go`.
+
+### Task 3.2: `_enable_access`
+- **Proto:** `rpc EnableAccess(UpdateAccessRequest) returns (UpdateAccessResponse) { option = {post: "/v1/admin/enable_access" body: "*"}; }` (reuse messages from 3.1).
+- **Service:** body from `enable_access.go`.
+
+### Task 3.3: `_invite_members`
+- **Proto:** `rpc InviteMembers(InviteMemberRequest) returns (InviteMembersResponse) { option = {post: "/v1/admin/invite_members" body: "*"}; }`. `InviteMemberRequest { repeated string emails = 1 [(buf.validate.field).repeated.min_items = 1]; string redirect_uri = 2; }` (mirror model). `InviteMembersResponse` mirroring `model.InviteMembersResponse` (likely `repeated User users = 1;` — confirm) — add projection.
+- **Service:** body from `invite_members.go`.
+
+**Phase 3 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminAccess' ./internal/integration_tests/`
+
+---
+
+## Phase 4 — Webhooks (7 ops)
+
+Add a proto `Webhook` message mirroring `model.Webhook`, `WebhookLog` mirroring
+`model.WebhookLog`, and list wrappers. Add `projectWebhook`, `projectWebhooks`,
+`projectWebhookLogs` to `admin_project.go`.
+
+### Task 4.1: `_add_webhook`
+- **Proto:** `rpc AddWebhook(AddWebhookRequest) returns (AddWebhookResponse) { option = {post: "/v1/admin/add_webhook" body: "*"}; }`. `AddWebhookRequest` mirroring `model.AddWebhookRequest` (event_name(s), endpoint required, enabled, headers map, event_description). `AddWebhookResponse { Response response = 1; }`.
+- **Service:** body from `add_webhook.go`.
+
+### Task 4.2: `_update_webhook`
+- **Proto:** `rpc UpdateWebhook(UpdateWebhookRequest) returns (UpdateWebhookResponse) { option = {post: "/v1/admin/update_webhook" body: "*"}; }`. `UpdateWebhookRequest` mirroring `model.UpdateWebhookRequest` (id required + optional fields). `UpdateWebhookResponse { Response response = 1; }`.
+- **Service:** body from `update_webhook.go`.
+
+### Task 4.3: `_delete_webhook`
+- **Proto:** `rpc DeleteWebhook(WebhookRequest) returns (DeleteWebhookResponse) { option = {post: "/v1/admin/delete_webhook" body: "*"}; }`. `WebhookRequest { string id = 1 [(buf.validate.field).required = true]; }`. `DeleteWebhookResponse { Response response = 1; }`.
+- **Service:** body from `delete_webhook.go`.
+
+### Task 4.4: `_webhook`
+- **Proto:** `rpc Webhook(WebhookRequest) returns (WebhookResponse) { option = {post: "/v1/admin/webhook" body: "*"}; }` (reuse `WebhookRequest` from 4.3). `WebhookResponse { Webhook webhook = 1; }`.
+- **Service:** body from `webhook.go`. Projection `projectWebhook`.
+
+### Task 4.5: `_webhooks`
+- **Proto:** `rpc Webhooks(AdminWebhooksRequest) returns (AdminWebhooksResponse) { option = {post: "/v1/admin/webhooks" body: "*"}; }`. Request `{ Pagination pagination = 1; }`. Response mirroring `model.Webhooks` (`repeated Webhook webhooks = 1; Pagination pagination = 2;`).
+- **Service:** body from `webhooks.go`. Projection `projectWebhooks`.
+
+### Task 4.6: `_webhook_logs`
+- **Proto:** `rpc WebhookLogs(ListWebhookLogRequest) returns (WebhookLogsResponse) { option = {post: "/v1/admin/webhook_logs" body: "*"}; }`. `ListWebhookLogRequest` mirroring `model.ListWebhookLogRequest` (pagination + optional webhook_id). Response mirroring `model.WebhookLogs` + `WebhookLog` message.
+- **Service:** body from `webhook_logs.go`. Projection `projectWebhookLogs`.
+
+### Task 4.7: `_test_endpoint`
+- **Proto:** `rpc TestEndpoint(TestEndpointRequest) returns (TestEndpointResponse) { option = {post: "/v1/admin/test_endpoint" body: "*"}; }`. `TestEndpointRequest` mirroring `model.TestEndpointRequest` (endpoint required, event_name, headers). `TestEndpointResponse` mirroring `model.TestEndpointResponse` (http_status, response, etc.).
+- **Service:** body from `test_endpoint.go`. Add `projectTestEndpointResponse`.
+
+**Phase 4 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminWebhook' ./internal/integration_tests/`
+
+---
+
+## Phase 5 — Email templates (4 ops)
+
+Add proto `EmailTemplate` mirroring `model.EmailTemplate`, list wrapper, and
+`projectEmailTemplate(s)`.
+
+### Task 5.1: `_add_email_template`
+- **Proto:** `rpc AddEmailTemplate(AddEmailTemplateRequest) returns (AddEmailTemplateResponse) { option = {post: "/v1/admin/add_email_template" body: "*"}; }`. Request mirroring `model.AddEmailTemplateRequest` (event_name required, subject, template, design). Response `{ Response response = 1; }`.
+- **Service:** body from `add_email_template.go`.
+
+### Task 5.2: `_update_email_template`
+- **Proto:** `rpc UpdateEmailTemplate(UpdateEmailTemplateRequest) returns (UpdateEmailTemplateResponse) { option = {post: "/v1/admin/update_email_template" body: "*"}; }`. Request mirroring `model.UpdateEmailTemplateRequest` (id required + optional fields). Response `{ Response response = 1; }`.
+- **Service:** body from `update_email_template.go`.
+
+### Task 5.3: `_delete_email_template`
+- **Proto:** `rpc DeleteEmailTemplate(DeleteEmailTemplateRequest) returns (DeleteEmailTemplateResponse) { option = {post: "/v1/admin/delete_email_template" body: "*"}; }`. `DeleteEmailTemplateRequest { string id = 1 [(buf.validate.field).required = true]; }`. Response `{ Response response = 1; }`.
+- **Service:** body from `delete_email_template.go`.
+
+### Task 5.4: `_email_templates`
+- **Proto:** `rpc EmailTemplates(AdminEmailTemplatesRequest) returns (AdminEmailTemplatesResponse) { option = {post: "/v1/admin/email_templates" body: "*"}; }`. Request `{ Pagination pagination = 1; }`. Response mirroring `model.EmailTemplates`.
+- **Service:** body from `email_templates.go`. Projection `projectEmailTemplates`.
+
+**Phase 5 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminEmailTemplate' ./internal/integration_tests/`
+
+---
+
+## Phase 6 — Audit (1 op)
+
+### Task 6.1: `_audit_logs`
+- **Proto:** `rpc AuditLogs(ListAuditLogRequest) returns (AuditLogsResponse) { option = {post: "/v1/admin/audit_logs" body: "*"}; }`. `ListAuditLogRequest` mirroring `model.ListAuditLogRequest` (pagination + filters). Response mirroring `model.AuditLogs` + `AuditLog` message.
+- **Service:** body from `audit_logs.go`. Add `projectAuditLogs`.
+
+**Phase 6 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminAuditLogs' ./internal/integration_tests/`
+
+---
+
+## Phase 7 — FGA admin (8 ops)
+
+Reuse existing proto FGA messages where the public surface defined them
+(`FgaModel`, `FgaTuples`, etc.). For inputs/outputs unique to admin FGA, add
+messages mirroring the corresponding `model.Fga*` types. Implement methods in
+`internal/service/admin_fga.go` (or extend `fga.go`); each calls
+`requireSuperAdmin` then the existing FGA engine logic migrated from the
+resolver. All FGA admin methods MUST fail closed when `p.AuthzEngine == nil`.
+
+### Task 7.1: `_fga_get_model`
+- **Proto:** `rpc FgaGetModel(FgaGetModelRequest) returns (FgaGetModelResponse) { option = {get: "/v1/admin/fga/model"}; }`. `FgaGetModelRequest {}`, `FgaGetModelResponse { FgaModel model = 1; }`.
+- **Service:** body from `fga_get_model.go`.
+
+### Task 7.2: `_fga_write_model`
+- **Proto:** `rpc FgaWriteModel(FgaWriteModelInput) returns (FgaWriteModelResponse) { option = {post: "/v1/admin/fga/model" body: "*"}; }`. `FgaWriteModelInput` mirroring `model.FgaWriteModelInput`. Response `{ FgaModel model = 1; }`.
+- **Service:** body from `fga_write_model.go`.
+
+### Task 7.3: `_fga_write_tuples`
+- **Proto:** `rpc FgaWriteTuples(FgaWriteTuplesInput) returns (FgaWriteTuplesResponse) { option = {post: "/v1/admin/fga/tuples" body: "*"}; }`. `FgaWriteTuplesInput` mirroring `model.FgaWriteTuplesInput`. Response `{ Response response = 1; }`.
+- **Service:** body from `fga_write_tuples.go`.
+
+### Task 7.4: `_fga_delete_tuples`
+- **Proto:** `rpc FgaDeleteTuples(FgaWriteTuplesInput) returns (FgaDeleteTuplesResponse) { option = {post: "/v1/admin/fga/tuples/delete" body: "*"}; }` (reuse input from 7.3). Response `{ Response response = 1; }`.
+- **Service:** body from `fga_delete_tuples.go`.
+
+### Task 7.5: `_fga_read_tuples`
+- **Proto:** `rpc FgaReadTuples(FgaReadTuplesInput) returns (FgaReadTuplesResponse) { option = {post: "/v1/admin/fga/tuples/read" body: "*"}; }`. `FgaReadTuplesInput` mirroring `model.FgaReadTuplesInput`. Response mirroring `model.FgaTuples` (`FgaTuples tuples = 1;` or `repeated FgaTuple ...`).
+- **Service:** body from `fga_read_tuples.go`.
+
+### Task 7.6: `_fga_list_users`
+- **Proto:** `rpc FgaListUsers(FgaListUsersInput) returns (FgaListUsersResponse) { option = {post: "/v1/admin/fga/list_users" body: "*"}; }`. Input + response mirroring `model.FgaListUsersInput` / `model.FgaListUsersResponse`.
+- **Service:** body from `fga_list_users.go`.
+
+### Task 7.7: `_fga_expand`
+- **Proto:** `rpc FgaExpand(FgaExpandInput) returns (FgaExpandResponse) { option = {post: "/v1/admin/fga/expand" body: "*"}; }`. Input + response mirroring `model.FgaExpandInput` / `model.FgaExpandResponse`.
+- **Service:** body from `fga_expand.go`.
+
+### Task 7.8: `_fga_reset`
+- **Proto:** `rpc FgaReset(FgaResetRequest) returns (FgaResetResponse) { option = {post: "/v1/admin/fga/reset" body: "*"}; }`. `FgaResetRequest {}`, `FgaResetResponse { Response response = 1; }`.
+- **Service:** body from `fga_reset.go`.
+
+**Phase 7 gate:** `TEST_DBS="sqlite" go test -p 1 -run 'TestAdminFga' ./internal/integration_tests/`
+
+---
+
+## Phase 8 — Finalize
+
+### Task 8.1: Enable the AdminProvider compile-time assertion
+
+- [ ] Remove the build tag from `admin_provider_test.go`; add to `provider.go`:
+
+```go
+var _ AdminProvider = (*provider)(nil)
+```
+
+- [ ] Tighten `server.go` to use the embedded-interface `Dependencies.ServiceProvider` (Provider + AdminProvider) and drop the runtime type assertion from Task 0.3.
+- [ ] Run: `go build ./... && go vet ./...`
+- [ ] Commit: `chore(admin-api): assert AdminProvider implemented; tighten wiring`.
+
+### Task 8.2: Smoke test
+
+**Files:** Modify `internal/e2e/smoke_test.go`.
+
+- [ ] Add a `--- Surface: Admin ---` block after the existing surfaces. Using the admin secret from server args:
+  - REST `GET /v1/admin/meta` with header `x-authorizer-admin-secret` → 200, roles present.
+  - REST `POST /v1/admin/users` `{}` with admin secret → 200, users array.
+  - REST `GET /v1/admin/meta` WITHOUT secret → 401 (fail-closed).
+  - gRPC `AuthorizerAdminService/AdminMeta` with `x-authorizer-admin-secret` metadata → roles.
+- [ ] Run: `go test -v -run TestReleaseSmoke ./internal/e2e/`
+- [ ] Commit: `test(admin-api): admin surface smoke coverage`.
+
+### Task 8.3: Proto lint/breaking + full build
+
+- [ ] Run: `make proto-lint && make proto-breaking && go build ./... && TEST_DBS="sqlite" go test -p 1 ./internal/integration_tests/`
+- [ ] Fix any failures. Commit.
+
+### Task 8.4: Docs (authorizer-docs, branch `feat/authorizer-admin-apis`)
+
+**Files:** `docs/core/graphql-api.md`, `docs/core/rest-api.md`, `docs/core/grpc.md`.
+
+- [ ] In each page, split the Table of Contents into **Public APIs** and **Authorizer Admin APIs** sections.
+- [ ] `rest-api.md`: add each `/v1/admin/*` endpoint (method, path, request/response, auth header `x-authorizer-admin-secret` or admin cookie) under the new admin section.
+- [ ] `grpc.md`: add `AuthorizerAdminService` with each RPC under the admin section; note same server/port as `AuthorizerService`.
+- [ ] `graphql-api.md`: ensure the `_`-prefixed ops are documented under the admin section of the TOC.
+- [ ] Build docs: `cd authorizer-docs && npm run build` (or the repo's documented build) → zero warnings.
+- [ ] Commit on `feat/authorizer-admin-apis`: `docs(core): split Public/Admin API TOC + document admin API`.
+
+---
+
+## Self-review checklist (run before execution)
+
+- [ ] Every op in the 32-op table maps to a task (Phases 1–7). ✓ (4+5+3+7+4+1+8 = 32)
+- [ ] No deprecated op included (`_admin_signup`, `_env`, `_update_env`, `_generate_jwt_keys` excluded). ✓
+- [ ] Single gRPC server + single gateway (Tasks 0.3, 0.4). ✓
+- [ ] Smoke test added (Task 8.2). ✓
+- [ ] Docs split TOC on all 3 pages (Task 8.4). ✓
+- [ ] Method signatures consistent between `admin_provider.go` and per-op tasks. ✓
+- [ ] Before generating each proto message, confirm field-for-field parity with the referenced `internal/graph/model` type.


### PR DESCRIPTION
## Summary

Documents the new **AuthorizerAdminService** (admin API over GraphQL, REST, and gRPC) and reorganizes the three core API reference pages so Public and Admin APIs are clearly separated.

Companion to the server PR (`authorizerdev/authorizer#631`).

## Changes

- **`docs/core/graphql-api.md`**, **`rest-api.md`**, **`grpc.md`**: each Table of Contents split into **Public APIs** and **Authorizer Admin APIs** sections.
- All 32 admin operations documented under the admin section, grouped by domain (auth & meta, users, access, webhooks, email templates, audit, FGA), sourced from the generated OpenAPI spec.
- Admin auth requirement (`x-authorizer-admin-secret` header or admin session cookie) called out; noted that admin ops are not exposed over MCP and that `AuthorizerAdminService` runs on the same gRPC server/port as `AuthorizerService`.
- Design spec + implementation plan added under `specs/`.

## Verification

- Docusaurus build passes with zero broken-anchor warnings (`npm run build`).