### PR TITLE
docs(core): flat response envelope + REST cookies for /v1

### DIFF
--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -100,8 +100,8 @@ attach the user's credential as request metadata —
 ## Protobuf schema
 
 The schema is published to the **[Buf Schema Registry](https://buf.build/authorizerdev/authorizer)**
-as the module `buf.build/authorizerdev/authorizer` (package `authorizer.v1`, with shared
-messages in `authorizer.common.v1`). You can generate a typed client for any language
+as the module `buf.build/authorizerdev/authorizer` (all messages live in a single
+`authorizer.v1` package). You can generate a typed client for any language
 without copying `.proto` files around:
 
 ```yaml
@@ -141,6 +141,13 @@ languages.
 
 Each message mirrors its GraphQL/REST counterpart — see the linked
 [GraphQL API reference](./graphql-api) anchor for field-level details.
+
+> **Response types.** Methods return the bare domain message — there is no per-RPC wrapper.
+> `Signup`, `Login`, `VerifyEmail`, `VerifyOtp`, and `Session` return `AuthResponse`;
+> `Profile` returns `User`; `Meta` returns `Meta`. This keeps the gRPC, REST, and GraphQL
+> payloads identical. Cookie-setting flows (login/signup/session/verify_\*, and the MFA
+> challenge flows) emit the session/MFA cookies as `set-cookie` response metadata, which the
+> REST gateway promotes to real `Set-Cookie` headers.
 
 ### `Meta`
 

--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -92,10 +92,30 @@ Table of Contents
 | TLS                   | `--grpc-tls-cert` + `--grpc-tls-key`; `--grpc-insecure` for dev    |
 | Server reflection     | `--enable-grpc-reflection` (default `true`)                        |
 | Health checking       | `grpc.health.v1.Health` (always registered)                       |
+| JSON field casing (REST)| `snake_case` via `UseProtoNames` — payloads match GraphQL byte-for-byte |
 
-The gRPC server is enabled by default. Auth flows over gRPC exactly as it does over REST:
+The gRPC server is enabled by default. Auth flows over gRPC exactly as they do over REST:
 attach the user's credential as request metadata —
-`authorization: Bearer <access_token>` — or a session cookie.
+`authorization: Bearer <access_token>` — or forward the `cookie` header from a browser
+session.
+
+### Session cookies over gRPC and REST
+
+Cookie-setting flows (`Signup`, `Login`, `Session`, `VerifyEmail`, `VerifyOtp`, and MFA
+challenge paths) emit session/MFA cookies as `set-cookie` **gRPC response metadata**. Over
+native gRPC, clients that need cookie-based auth must read these metadata headers and
+forward the `Cookie` value on subsequent calls. Over REST, the grpc-gateway promotes them
+to real `Set-Cookie` HTTP headers (previously they surfaced as
+`Grpc-Metadata-Set-Cookie`, which browsers ignored).
+
+| Cookie | gRPC metadata / REST header | Set by |
+| ------ | --------------------------- | ------ |
+| App session (`cookie_session`, `cookie_session_domain`) | `set-cookie` → `Set-Cookie` | `Signup`, `Login`, `Session`, `VerifyEmail`, `VerifyOtp` |
+| MFA challenge (`mfa`) | `set-cookie` → `Set-Cookie` | `Login`, `ForgotPassword`, `ResendOtp` when MFA is required |
+| Admin session (`authorizer-admin`) | `set-cookie` → `Set-Cookie` | `AdminLogin`, `AdminSession` |
+
+Admin auth also accepts `x-authorizer-admin-secret` as incoming metadata (mirrored from
+the REST `X-Authorizer-Admin-Secret` header).
 
 ## Protobuf schema
 
@@ -145,9 +165,19 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 > **Response types.** Methods return the bare domain message — there is no per-RPC wrapper.
 > `Signup`, `Login`, `VerifyEmail`, `VerifyOtp`, and `Session` return `AuthResponse`;
 > `Profile` returns `User`; `Meta` returns `Meta`. This keeps the gRPC, REST, and GraphQL
-> payloads identical. Cookie-setting flows (login/signup/session/verify_\*, and the MFA
-> challenge flows) emit the session/MFA cookies as `set-cookie` response metadata, which the
-> REST gateway promotes to real `Set-Cookie` headers.
+> payloads identical (snake_case field names, no `auth` / `user` / `meta` envelope keys).
+> Request messages are likewise flat — send the RPC input fields directly.
+>
+> Example — `Login` returns a flat `AuthResponse` (not `{ "auth": { … } }`):
+>
+> ```json
+> {
+>   "message": "Logged in successfully",
+>   "access_token": "eyJhbGciOiJIUzI1NiIs…",
+>   "expires_in": 1718534400,
+>   "user": { "id": "…", "email": "jane@example.com" }
+> }
+> ```
 
 ### `Meta`
 
@@ -386,7 +416,12 @@ With reflection enabled you can explore and call the service directly:
 grpcurl -plaintext localhost:9091 list
 
 # Describe a method
-grpcurl -plaintext localhost:9091 describe authorizer.v1.AuthorizerService.CheckPermissions
+grpcurl -plaintext localhost:9091 describe authorizer.v1.AuthorizerService.Login
+
+# Login (public) — response is a flat AuthResponse; check -H for set-cookie metadata
+grpcurl -plaintext \
+  -d '{"email":"jane@example.com","password":"Test@123"}' \
+  localhost:9091 authorizer.v1.AuthorizerService/Login
 
 # Check permissions (authenticated)
 grpcurl -plaintext \

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -111,8 +111,11 @@ Authenticated endpoints accept the user's credentials in either of two ways — 
 the GraphQL API does:
 
 - **Bearer token** — `Authorization: Bearer <access_token>`
-- **Session cookie** — the `Set-Cookie` returned by `login`/`session` is honored on
-  subsequent calls.
+- **Session cookie** — the `Set-Cookie` headers returned by `signup`, `login`, `session`,
+  `verify_email`, and `verify_otp` are honored on subsequent calls. MFA-challenge flows
+  (`login`/`forgot_password`/`resend_otp` when OTP/TOTP is required) set a short-lived MFA
+  cookie the same way. Browser clients store and resend these automatically; the cookie
+  pair is host-scoped and domain-scoped, exactly as on the GraphQL surface.
 
 ```bash
 curl -X GET https://auth.example.com/v1/profile \
@@ -133,6 +136,14 @@ require the admin secret / admin session. See [GraphQL API](./graphql-api) for t
 Every endpoint below accepts/returns the same fields as its GraphQL counterpart. For the
 full field-by-field breakdown of each request and response, follow the linked anchor in
 the [GraphQL API reference](./graphql-api).
+
+> **Response shape — no envelope wrapper.** Each endpoint returns the bare domain object,
+> byte-identical to the GraphQL response. `signup`, `login`, `verify_email`, `verify_otp`,
+> and `session` return the `AuthResponse` fields at the top level
+> (`{ "message", "access_token", "id_token", "refresh_token", "expires_in", "user", … }`) —
+> **not** wrapped under an `auth` key. `profile` returns the `User` object directly and
+> `meta` returns the `Meta` object directly. The remaining endpoints return
+> `{ "message": "…" }` (or their documented fields).
 
 ### `POST /v1/signup`
 

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -28,6 +28,7 @@ Table of Contents
 
 - [Base URL & transport](#base-url--transport)
 - [Authentication](#authentication)
+  - [Session cookies](#session-cookies)
 - [Public Endpoints](#public-api-endpoints)
   - [`POST /v1/signup`](#post-v1signup)
   - [`POST /v1/login`](#post-v1login)
@@ -100,6 +101,7 @@ Table of Contents
 | HTTP port       | `--http-port` (default `8080`)                                         |
 | Content type    | `application/json` for request and response bodies                     |
 | Field casing    | `snake_case` (proto field names), matching the GraphQL field names     |
+| Request bodies  | Flat JSON object — the RPC request message fields at the top level (no wrapper) |
 | gRPC port       | `--grpc-port` (default `9091`) — same operations over native gRPC      |
 
 So if your instance is at `https://auth.example.com`, the permission-check endpoint is
@@ -111,20 +113,60 @@ Authenticated endpoints accept the user's credentials in either of two ways — 
 the GraphQL API does:
 
 - **Bearer token** — `Authorization: Bearer <access_token>`
-- **Session cookie** — the `Set-Cookie` headers returned by `signup`, `login`, `session`,
-  `verify_email`, and `verify_otp` are honored on subsequent calls. MFA-challenge flows
-  (`login`/`forgot_password`/`resend_otp` when OTP/TOTP is required) set a short-lived MFA
-  cookie the same way. Browser clients store and resend these automatically; the cookie
-  pair is host-scoped and domain-scoped, exactly as on the GraphQL surface.
+- **Session cookie** — see [Session cookies](#session-cookies) below
 
 ```bash
 curl -X GET https://auth.example.com/v1/profile \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
-Super-admin-only operations (the `_fga_*` model/tuple management mutations, env, users,
-webhooks, etc.) are **not** part of the REST surface — they remain GraphQL-only and
-require the admin secret / admin session. See [GraphQL API](./graphql-api) for those.
+Super-admin endpoints live under `/v1/admin/*` (see [Authorizer Admin API Endpoints](#authorizer-admin-api-endpoints)).
+They accept the same two mechanisms as GraphQL admin calls: `x-authorizer-admin-secret` or
+the `authorizer-admin` HTTP-only session cookie set by `POST /v1/admin/login`.
+
+### Session cookies
+
+Cookie-based auth works the same over REST as over GraphQL. On successful auth the server
+returns real `Set-Cookie` response headers (not `Grpc-Metadata-Set-Cookie`). Browser clients
+should send `credentials: 'include'` on `fetch` (or the equivalent in your HTTP client) so
+the cookie is stored and resent automatically.
+
+| Cookie name | Set by | Purpose |
+| ----------- | ------ | ------- |
+| `cookie_session`, `cookie_session_domain` | `signup`, `login`, `session`, `verify_email`, `verify_otp` | App session pair (HTTP-only; host-scoped + domain-scoped) |
+| `mfa` | `login`, `forgot_password`, `resend_otp` when MFA is required | Short-lived MFA challenge session |
+| `authorizer-admin` | `POST /v1/admin/login`, `GET /v1/admin/session` | Super-admin session |
+
+**Browser example** — login and call an authenticated endpoint with the session cookie:
+
+```javascript
+// 1. Login — browser stores Set-Cookie automatically
+await fetch('https://auth.example.com/v1/login', {
+  method: 'POST',
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ email: 'jane@example.com', password: 'Test@123' }),
+});
+
+// 2. Subsequent calls — cookie sent automatically
+const profile = await fetch('https://auth.example.com/v1/profile', {
+  credentials: 'include',
+});
+```
+
+**curl example** — capture cookies in a jar and reuse them:
+
+```bash
+curl -c cookies.txt -X POST https://auth.example.com/v1/login \
+  -H "Content-Type: application/json" \
+  -d '{ "email": "jane@example.com", "password": "Test@123" }'
+
+curl -b cookies.txt https://auth.example.com/v1/profile
+```
+
+Server-side REST clients that are not behind a browser should forward the `Cookie` header
+on authenticated calls, or use a bearer token from the `access_token` field in the JSON
+response body instead.
 
 > **CSRF note:** From `v2.3.0` onward, state-changing `POST` requests are rejected with
 > `403` unless they carry an `Origin` (or `Referer`) header. Browsers send this
@@ -141,9 +183,37 @@ the [GraphQL API reference](./graphql-api).
 > byte-identical to the GraphQL response. `signup`, `login`, `verify_email`, `verify_otp`,
 > and `session` return the `AuthResponse` fields at the top level
 > (`{ "message", "access_token", "id_token", "refresh_token", "expires_in", "user", … }`) —
-> **not** wrapped under an `auth` key. `profile` returns the `User` object directly and
-> `meta` returns the `Meta` object directly. The remaining endpoints return
-> `{ "message": "…" }` (or their documented fields).
+> **not** wrapped under an `auth` key. `profile` returns the `User` object directly (not
+> under `user`) and `meta` returns the `Meta` object directly (not under `meta`). The
+> remaining endpoints return `{ "message": "…" }` (or their documented fields).
+>
+> Example — `POST /v1/login` response (flat `AuthResponse`):
+>
+> ```json
+> {
+>   "message": "Logged in successfully",
+>   "access_token": "eyJhbGciOiJIUzI1NiIs…",
+>   "expires_in": 1718534400,
+>   "id_token": "eyJhbGciOiJIUzI1NiIs…",
+>   "refresh_token": "…",
+>   "user": {
+>     "id": "…",
+>     "email": "jane@example.com",
+>     "roles": ["user"]
+>   }
+> }
+> ```
+>
+> Example — `GET /v1/profile` response (flat `User`):
+>
+> ```json
+> {
+>   "id": "…",
+>   "email": "jane@example.com",
+>   "roles": ["user"],
+>   "given_name": "Jane"
+> }
+> ```
 
 ### `POST /v1/signup`
 
@@ -328,7 +398,8 @@ All admin endpoints require super-admin authentication via the `x-authorizer-adm
 
 #### `POST /v1/admin/login`
 
-Authenticate as super-admin with the admin secret. Returns a session token.
+Authenticate as super-admin with the admin secret. Sets the `authorizer-admin` session
+cookie via `Set-Cookie` (same as GraphQL `_admin_login`).
 
 **Request body**
 
@@ -693,24 +764,28 @@ Delete the entire fine-grained authorization store (model, all versions, and all
 
 ## Errors
 
-REST errors follow the grpc-gateway convention: a non-`200` HTTP status with a JSON body
-containing a `code` and `message`.
+REST errors return a non-`200` HTTP status with a stable JSON envelope:
 
 ```json
 {
-  "code": 7,
+  "code": "failed_precondition",
   "message": "fga is not enabled on this server"
 }
 ```
 
+`code` is a snake_case gRPC status token (for example `invalid_argument`, `unauthenticated`,
+`permission_denied`, `not_found`, `method_not_allowed`). `message` is a human-readable
+description.
+
 Common cases:
 
-| Situation                                  | HTTP status        |
-| ------------------------------------------ | ------------------ |
-| Missing/invalid credentials                | `401 Unauthorized` |
-| Explicit `user` not permitted for caller   | `403 Forbidden`    |
-| FGA not enabled (`--fga-store` unset)      | `400 Bad Request`  |
-| Validation failure (e.g. `> 100` checks)   | `400 Bad Request`  |
+| Situation                                  | HTTP status        | `code` (typical)        |
+| ------------------------------------------ | ------------------ | ----------------------- |
+| Missing/invalid credentials                | `401 Unauthorized` | `unauthenticated`       |
+| Explicit `user` not permitted for caller   | `403 Forbidden`    | `permission_denied`     |
+| FGA not enabled (`--fga-store` unset)      | `400 Bad Request`  | `failed_precondition`   |
+| Validation failure (e.g. `> 100` checks)   | `400 Bad Request`  | `invalid_argument`      |
+| Wrong HTTP method (e.g. `GET` on `POST`)   | `405 Method Not Allowed` | `method_not_allowed` |
 
 ## See also
 

--- a/docs/sdks/authorizer-go/admin.md
+++ b/docs/sdks/authorizer-go/admin.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 3
+title: Protocols & Admin API
+---
+
+# Protocols & Admin API
+
+_Added in authorizer-go for Authorizer **2.3.0-rc.9**._
+
+## Protocol selection
+
+The user client can talk to the server over three wire protocols. **`graphql` is the
+default** and is 100% backward compatible — existing code keeps working unchanged.
+
+| Protocol           | Transport                       | Notes                                          |
+| ------------------ | ------------------------------- | ---------------------------------------------- |
+| `ProtocolGraphQL`  | `POST /graphql`                 | Default.                                       |
+| `ProtocolREST`     | Typed `POST/GET /v1/...` routes | Same flat responses as GraphQL.                |
+| `ProtocolGRPC`     | Generated gRPC stub             | Uses a **separate endpoint** (default `:9091`). |
+
+Pass `WithProtocol` to `NewAuthorizerClient`. As of 2.3.0-rc.9 all 20 public methods work
+over every protocol, and all three return **identical flat response shapes**.
+
+```go
+// REST (default endpoint, no extra config)
+client, err := authorizer.NewAuthorizerClient(
+    "YOUR_CLIENT_ID", "YOUR_AUTHORIZER_URL", "", nil,
+    authorizer.WithProtocol(authorizer.ProtocolREST),
+)
+```
+
+### gRPC
+
+gRPC listens on its own port, separate from the HTTP URL. When `WithGRPCEndpoint` is
+omitted, the target is derived from the Authorizer URL's host with the default gRPC port
+`9091`.
+
+```go
+client, err := authorizer.NewAuthorizerClient(
+    "YOUR_CLIENT_ID", "https://your-instance.authorizer.dev", "", nil,
+    authorizer.WithProtocol(authorizer.ProtocolGRPC),
+    authorizer.WithGRPCEndpoint("your-instance.authorizer.dev:9091"), // optional
+)
+if err != nil {
+    panic(err)
+}
+
+res, err := client.Login(&authorizer.LoginInput{Email: "user@example.com", Password: "Abc@123"})
+```
+
+> OAuth endpoints (`/oauth/token`, `/oauth/revoke`) always use REST regardless of the
+> selected protocol.
+
+## Admin client
+
+The admin API is a **separate client** constructed with the admin secret (the value of
+`--admin-secret`). Admin auth is sent on every call as the `x-authorizer-admin-secret`
+header (gRPC: metadata key `x-authorizer-admin-secret`).
+
+```go
+admin, err := authorizer.NewAuthorizerAdminClient(
+    "https://your-instance.authorizer.dev", "YOUR_ADMIN_SECRET",
+)
+if err != nil {
+    panic(err)
+}
+
+// List users
+res, err := admin.Users(&authorizerv1.UsersRequest{})
+if err != nil {
+    panic(err)
+}
+for _, u := range res.Users {
+    fmt.Println(u.Email)
+}
+```
+
+Request/response types come from the generated proto package
+(`authorizerv1 "github.com/authorizerdev/authorizer-go/gen/..."`); import it alongside the SDK.
+
+### Admin client options
+
+| Option                       | Description                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `WithAdminProtocol(p)`       | Wire transport. Defaults to `ProtocolGraphQL`.                           |
+| `WithAdminGRPCEndpoint(addr)`| gRPC target (default: URL host + `:9091`).                              |
+| `WithAdminExtraHeaders(h)`   | Extra headers sent on every admin request.                              |
+
+```go
+admin, err := authorizer.NewAuthorizerAdminClient(
+    "https://your-instance.authorizer.dev", "YOUR_ADMIN_SECRET",
+    authorizer.WithAdminProtocol(authorizer.ProtocolGRPC),
+    authorizer.WithAdminGRPCEndpoint("your-instance.authorizer.dev:9091"),
+)
+```
+
+### Admin methods
+
+Each method declares which protocols support it. Calling a method on an unsupported
+protocol raises a clear error early (e.g. _"AdminMeta is not available over graphql"_)
+rather than emitting a 404. The protocol columns below also apply to the Python and JS
+admin clients (JS supports graphql + rest only).
+
+> **⚠ Destructive:** `DeleteUser`, `DeleteWebhook`, `DeleteEmailTemplate`,
+> `FgaWriteModel` (overwrites the model), `FgaDeleteTuples`, and `FgaReset` (wipes all FGA
+> data) permanently change or remove data.
+
+#### Auth, session & meta
+
+| Method        | Description                                  | grpc | rest | gql |
+| ------------- | -------------------------------------------- | :--: | :--: | :-: |
+| `AdminLogin`  | Exchange the admin secret for a session.     | ✓ | ✓ | ✓ |
+| `AdminLogout` | End the admin session.                       | ✓ | ✓ |   |
+| `AdminSession`| Get the current admin session.               | ✓ | ✓ |   |
+| `AdminMeta`   | Server metadata / feature flags.             | ✓ | ✓ |   |
+
+#### Users & access
+
+| Method                  | Description                                   | grpc | rest | gql |
+| ----------------------- | --------------------------------------------- | :--: | :--: | :-: |
+| `Users`                 | List users (paginated).                       | ✓ | ✓ | ✓ |
+| `User`                  | Get a single user.                            | ✓ | ✓ | ✓ |
+| `UpdateUser`            | Update a user.                                | ✓ | ✓ | ✓ |
+| `DeleteUser`            | **Delete a user.**                            | ✓ | ✓ | ✓ |
+| `VerificationRequests`  | List pending verification requests.           | ✓ | ✓ | ✓ |
+| `RevokeAccess`          | Revoke a user's access.                        | ✓ | ✓ | ✓ |
+| `EnableAccess`          | Re-enable a user's access.                     | ✓ | ✓ | ✓ |
+| `InviteMembers`         | Invite members by email.                      | ✓ | ✓ | ✓ |
+
+#### Webhooks
+
+| Method          | Description                       | grpc | rest | gql |
+| --------------- | -------------------------------- | :--: | :--: | :-: |
+| `AddWebhook`    | Create a webhook.                | ✓ | ✓ | ✓ |
+| `UpdateWebhook` | Update a webhook.                | ✓ | ✓ | ✓ |
+| `DeleteWebhook` | **Delete a webhook.**            | ✓ | ✓ | ✓ |
+| `GetWebhook`    | Get a single webhook.            | ✓ | ✓ | ✓ |
+| `Webhooks`      | List webhooks.                   | ✓ | ✓ | ✓ |
+| `WebhookLogs`   | List webhook delivery logs.      | ✓ | ✓ | ✓ |
+| `TestEndpoint`  | Send a test event to a webhook.  | ✓ | ✓ | ✓ |
+
+#### Email templates
+
+| Method                 | Description                  | grpc | rest | gql |
+| ---------------------- | ---------------------------- | :--: | :--: | :-: |
+| `AddEmailTemplate`     | Create an email template.    | ✓ | ✓ | ✓ |
+| `UpdateEmailTemplate`  | Update an email template.    | ✓ | ✓ | ✓ |
+| `DeleteEmailTemplate`  | **Delete an email template.**| ✓ | ✓ | ✓ |
+| `EmailTemplates`       | List email templates.        | ✓ | ✓ | ✓ |
+
+#### Audit
+
+| Method      | Description       | grpc | rest | gql |
+| ----------- | ----------------- | :--: | :--: | :-: |
+| `AuditLogs` | List audit logs.  | ✓ | ✓ | ✓ |
+
+#### FGA admin
+
+| Method            | Description                              | grpc | rest | gql |
+| ----------------- | ---------------------------------------- | :--: | :--: | :-: |
+| `FgaGetModel`     | Get the current FGA model.               | ✓ | ✓ |   |
+| `FgaWriteModel`   | **Write/overwrite the FGA model.**       | ✓ | ✓ | ✓ |
+| `FgaWriteTuples`  | Write relationship tuples.               | ✓ | ✓ | ✓ |
+| `FgaDeleteTuples` | **Delete relationship tuples.**          | ✓ | ✓ | ✓ |
+| `FgaReadTuples`   | Read relationship tuples.                | ✓ | ✓ | ✓ |
+| `FgaListUsers`    | List users with a relation to an object. | ✓ | ✓ | ✓ |
+| `FgaExpand`       | Expand a relation into its userset.      | ✓ | ✓ | ✓ |
+| `FgaReset`        | **Reset all FGA data.**                  | ✓ | ✓ |   |
+
+#### GraphQL-only extras
+
+These have no proto / REST / gRPC equivalent and work **over GraphQL only**:
+
+| Method            | Description                          |
+| ----------------- | ------------------------------------ |
+| `AdminSignup`     | Bootstrap the first admin.           |
+| `UpdateEnv`       | Update server environment/config.    |
+| `GenerateJWTKeys` | Generate a new JWT signing key pair. |

--- a/docs/sdks/authorizer-js/admin.md
+++ b/docs/sdks/authorizer-js/admin.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 3
+title: Protocols & Admin API
+---
+
+# Protocols & Admin API
+
+_Added in `@authorizerdev/authorizer-js` for Authorizer **2.3.0-rc.9**._
+
+## Protocol selection
+
+The `Authorizer` client can talk to the server over two wire protocols. **`graphql` is the
+default** and is 100% backward compatible — existing code keeps working unchanged.
+
+| `protocol` | Transport                       | Notes                           |
+| ---------- | ------------------------------- | ------------------------------- |
+| `'graphql'`| `POST /graphql`                 | Default.                        |
+| `'rest'`   | Typed `POST/GET /v1/...` routes | Same flat responses as GraphQL. |
+
+> **No gRPC in JS.** Browsers cannot speak raw gRPC. Passing `protocol: 'grpc'` throws a
+> clear error at construction time. Use the [Go](../authorizer-go/admin) or
+> [Python](../authorizer-python/admin) SDKs for gRPC.
+
+As of 2.3.0-rc.9 all public methods work over both protocols, and both return **identical
+flat response shapes**.
+
+```js
+import { Authorizer } from '@authorizerdev/authorizer-js'
+
+const authRef = new Authorizer({
+  authorizerURL: 'YOUR_AUTHORIZER_URL',
+  redirectURL: window.location.origin,
+  clientID: 'YOUR_CLIENT_ID',
+  protocol: 'rest', // 'graphql' (default) | 'rest'
+})
+
+await authRef.login({ email: 'user@example.com', password: 'Abc@123' })
+```
+
+> OAuth endpoints (`/oauth/token`, `/oauth/revoke`) always use REST regardless of the
+> selected protocol.
+
+## Admin client
+
+The admin API is a **separate client**, `AuthorizerAdmin`, constructed with the admin
+secret (the value of `--admin-secret`). Admin auth is sent on every call as the
+`x-authorizer-admin-secret` header.
+
+> Keep the admin secret on the **server side** — never ship it to a browser bundle.
+
+```js
+import { AuthorizerAdmin } from '@authorizerdev/authorizer-js'
+
+const admin = new AuthorizerAdmin({
+  authorizerURL: 'https://your-instance.authorizer.dev',
+  adminSecret: 'YOUR_ADMIN_SECRET',
+  protocol: 'graphql', // 'graphql' (default) | 'rest'
+})
+
+// List users
+const { data, errors } = await admin.users()
+if (!errors?.length) {
+  data.users.forEach((u) => console.log(u.email))
+}
+```
+
+### Config
+
+| Key             | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `authorizerURL` | Base URL of your Authorizer instance.                         |
+| `adminSecret`   | Value of `--admin-secret`, sent as `x-authorizer-admin-secret`.|
+| `protocol`      | `'graphql'` (default) or `'rest'`. gRPC is not supported.     |
+
+### Admin methods
+
+Each method declares which protocols support it. Calling a method on an unsupported
+protocol returns a clear error rather than emitting a 404.
+
+> **⚠ Destructive:** `deleteUser`, `deleteWebhook`, `deleteEmailTemplate`,
+> `fgaWriteModel` (overwrites the model), `fgaDeleteTuples`, and `fgaReset` (wipes all FGA
+> data) permanently change or remove data.
+
+#### Auth, session & meta
+
+| Method         | Description                              | rest | gql |
+| -------------- | ---------------------------------------- | :--: | :-: |
+| `adminLogin`   | Exchange the admin secret for a session. | ✓ | ✓ |
+| `adminLogout`  | End the admin session.                   | ✓ |   |
+| `adminSession` | Get the current admin session.           | ✓ |   |
+| `adminMeta`    | Server metadata / feature flags.         | ✓ |   |
+
+#### Users & access
+
+| Method                 | Description                         | rest | gql |
+| ---------------------- | ----------------------------------- | :--: | :-: |
+| `users`                | List users (paginated).             | ✓ | ✓ |
+| `user`                 | Get a single user.                  | ✓ | ✓ |
+| `updateUser`           | Update a user.                      | ✓ | ✓ |
+| `deleteUser`           | **Delete a user.**                  | ✓ | ✓ |
+| `verificationRequests` | List pending verification requests. | ✓ | ✓ |
+| `revokeAccess`         | Revoke a user's access.              | ✓ | ✓ |
+| `enableAccess`         | Re-enable a user's access.           | ✓ | ✓ |
+| `inviteMembers`        | Invite members by email.            | ✓ | ✓ |
+
+#### Webhooks
+
+| Method          | Description                      | rest | gql |
+| --------------- | -------------------------------- | :--: | :-: |
+| `addWebhook`    | Create a webhook.                | ✓ | ✓ |
+| `updateWebhook` | Update a webhook.                | ✓ | ✓ |
+| `deleteWebhook` | **Delete a webhook.**            | ✓ | ✓ |
+| `getWebhook`    | Get a single webhook.            | ✓ | ✓ |
+| `webhooks`      | List webhooks.                   | ✓ | ✓ |
+| `webhookLogs`   | List webhook delivery logs.      | ✓ | ✓ |
+| `testEndpoint`  | Send a test event to a webhook.  | ✓ | ✓ |
+
+#### Email templates
+
+| Method                | Description                  | rest | gql |
+| --------------------- | ---------------------------- | :--: | :-: |
+| `addEmailTemplate`    | Create an email template.    | ✓ | ✓ |
+| `updateEmailTemplate` | Update an email template.    | ✓ | ✓ |
+| `deleteEmailTemplate` | **Delete an email template.**| ✓ | ✓ |
+| `emailTemplates`      | List email templates.        | ✓ | ✓ |
+
+#### Audit
+
+| Method      | Description       | rest | gql |
+| ----------- | ----------------- | :--: | :-: |
+| `auditLogs` | List audit logs.  | ✓ | ✓ |
+
+#### FGA admin
+
+| Method            | Description                              | rest | gql |
+| ----------------- | ---------------------------------------- | :--: | :-: |
+| `fgaGetModel`     | Get the current FGA model.               | ✓ |   |
+| `fgaWriteModel`   | **Write/overwrite the FGA model.**       | ✓ | ✓ |
+| `fgaWriteTuples`  | Write relationship tuples.               | ✓ | ✓ |
+| `fgaDeleteTuples` | **Delete relationship tuples.**          | ✓ | ✓ |
+| `fgaReadTuples`   | Read relationship tuples.                | ✓ | ✓ |
+| `fgaListUsers`    | List users with a relation to an object. | ✓ | ✓ |
+| `fgaExpand`       | Expand a relation into its userset.      | ✓ | ✓ |
+| `fgaReset`        | **Reset all FGA data.**                  | ✓ |   |
+
+#### GraphQL-only extras
+
+These have no REST equivalent and work **over GraphQL only**:
+
+| Method            | Description                          |
+| ----------------- | ------------------------------------ |
+| `adminSignup`     | Bootstrap the first admin.           |
+| `updateEnv`       | Update server environment/config.    |
+| `generateJWTKeys` | Generate a new JWT signing key pair. |

--- a/docs/sdks/authorizer-python/admin.md
+++ b/docs/sdks/authorizer-python/admin.md
@@ -1,0 +1,185 @@
+---
+sidebar_position: 4
+title: Protocols & Admin API
+---
+
+# Protocols & Admin API
+
+_Added in `authorizer-py` for Authorizer **2.3.0-rc.9**._
+
+## Protocol selection
+
+Both the sync (`AuthorizerClient`) and async (`AsyncAuthorizerClient`) user clients can
+talk to the server over three wire protocols. **`graphql` is the default** and is 100%
+backward compatible — existing code keeps working unchanged.
+
+| `protocol=` | Transport                       | Notes                                          |
+| ----------- | ------------------------------- | ---------------------------------------------- |
+| `"graphql"` | `POST /graphql`                 | Default.                                       |
+| `"rest"`    | Typed `POST/GET /v1/...` routes | Same flat responses as GraphQL.                |
+| `"grpc"`    | Generated gRPC stub             | Uses a **separate endpoint** (default `:9091`). |
+
+As of 2.3.0-rc.9 all public methods work over every protocol, and all three return
+**identical flat response shapes**.
+
+```python
+from authorizer import AuthorizerClient, LoginRequest
+
+# REST
+client = AuthorizerClient(
+    client_id="YOUR_CLIENT_ID",
+    authorizer_url="https://your-instance.authorizer.dev",
+    protocol="rest",
+)
+token = client.login(LoginRequest(email="user@example.com", password="Abc@123"))
+```
+
+### gRPC
+
+gRPC requires the optional extra:
+
+```bash
+pip install 'authorizer-py[grpc]'
+```
+
+It listens on its own port, separate from the HTTP URL. When `grpc_endpoint` is omitted,
+the target is derived from `authorizer_url`'s host with the default gRPC port `9091`.
+
+```python
+client = AuthorizerClient(
+    client_id="YOUR_CLIENT_ID",
+    authorizer_url="https://your-instance.authorizer.dev",
+    protocol="grpc",
+    grpc_endpoint="your-instance.authorizer.dev:9091",  # optional
+)
+```
+
+> OAuth endpoints (`/oauth/token`, `/oauth/revoke`) always use REST regardless of the
+> selected protocol.
+
+## Admin client
+
+The admin API is a **separate client** constructed with the admin secret (the value of
+`--admin-secret`) — `AuthorizerAdminClient` (sync) and `AsyncAuthorizerAdminClient`
+(async). Admin auth is sent on every call as the `x-authorizer-admin-secret` header (gRPC:
+metadata key `x-authorizer-admin-secret`).
+
+```python
+from authorizer import AuthorizerAdminClient
+
+admin = AuthorizerAdminClient(
+    authorizer_url="https://your-instance.authorizer.dev",
+    admin_secret="YOUR_ADMIN_SECRET",
+)
+
+# List users
+res = admin.users()
+for u in res.users:
+    print(u.email)
+
+admin.close()
+```
+
+The async client mirrors the sync one method-for-method; `await` the calls and use
+`async with` / `await admin.aclose()`.
+
+### Constructor options
+
+```python
+AuthorizerAdminClient(
+    authorizer_url: str,
+    admin_secret: str,
+    extra_headers: dict[str, str] | None = None,
+    protocol: str = "graphql",
+    grpc_endpoint: str = "",
+)
+```
+
+| Parameter        | Description                                                         | Required |
+| ---------------- | ------------------------------------------------------------------ | -------- |
+| `authorizer_url` | Base URL of your Authorizer instance, **no trailing slash**.       | yes      |
+| `admin_secret`   | Value of `--admin-secret`.                                         | yes      |
+| `extra_headers`  | Extra headers sent on every admin request.                         | no       |
+| `protocol`       | `"graphql"` (default), `"rest"`, or `"grpc"`.                      | no       |
+| `grpc_endpoint`  | gRPC target (default: URL host + `:9091`).                         | no       |
+
+### Admin methods
+
+Each method declares which protocols support it. Calling a method on an unsupported
+protocol raises a clear error early rather than emitting a 404.
+
+> **⚠ Destructive:** `delete_user`, `delete_webhook`, `delete_email_template`,
+> `fga_write_model` (overwrites the model), `fga_delete_tuples`, and `fga_reset` (wipes all
+> FGA data) permanently change or remove data.
+
+#### Auth, session & meta
+
+| Method          | Description                              | grpc | rest | gql |
+| --------------- | ---------------------------------------- | :--: | :--: | :-: |
+| `admin_login`   | Exchange the admin secret for a session. | ✓ | ✓ | ✓ |
+| `admin_logout`  | End the admin session.                   | ✓ | ✓ |   |
+| `admin_session` | Get the current admin session.           | ✓ | ✓ |   |
+| `admin_meta`    | Server metadata / feature flags.         | ✓ | ✓ |   |
+
+#### Users & access
+
+| Method                   | Description                         | grpc | rest | gql |
+| ------------------------ | ----------------------------------- | :--: | :--: | :-: |
+| `users`                  | List users (paginated).             | ✓ | ✓ | ✓ |
+| `user`                   | Get a single user.                  | ✓ | ✓ | ✓ |
+| `update_user`            | Update a user.                      | ✓ | ✓ | ✓ |
+| `delete_user`            | **Delete a user.**                  | ✓ | ✓ | ✓ |
+| `verification_requests`  | List pending verification requests. | ✓ | ✓ | ✓ |
+| `revoke_access`          | Revoke a user's access.              | ✓ | ✓ | ✓ |
+| `enable_access`          | Re-enable a user's access.           | ✓ | ✓ | ✓ |
+| `invite_members`         | Invite members by email.            | ✓ | ✓ | ✓ |
+
+#### Webhooks
+
+| Method           | Description                      | grpc | rest | gql |
+| ---------------- | -------------------------------- | :--: | :--: | :-: |
+| `add_webhook`    | Create a webhook.                | ✓ | ✓ | ✓ |
+| `update_webhook` | Update a webhook.                | ✓ | ✓ | ✓ |
+| `delete_webhook` | **Delete a webhook.**            | ✓ | ✓ | ✓ |
+| `get_webhook`    | Get a single webhook.            | ✓ | ✓ | ✓ |
+| `webhooks`       | List webhooks.                   | ✓ | ✓ | ✓ |
+| `webhook_logs`   | List webhook delivery logs.      | ✓ | ✓ | ✓ |
+| `test_endpoint`  | Send a test event to a webhook.  | ✓ | ✓ | ✓ |
+
+#### Email templates
+
+| Method                  | Description                  | grpc | rest | gql |
+| ----------------------- | ---------------------------- | :--: | :--: | :-: |
+| `add_email_template`    | Create an email template.    | ✓ | ✓ | ✓ |
+| `update_email_template` | Update an email template.    | ✓ | ✓ | ✓ |
+| `delete_email_template` | **Delete an email template.**| ✓ | ✓ | ✓ |
+| `email_templates`       | List email templates.        | ✓ | ✓ | ✓ |
+
+#### Audit
+
+| Method       | Description       | grpc | rest | gql |
+| ------------ | ----------------- | :--: | :--: | :-: |
+| `audit_logs` | List audit logs.  | ✓ | ✓ | ✓ |
+
+#### FGA admin
+
+| Method              | Description                              | grpc | rest | gql |
+| ------------------- | ---------------------------------------- | :--: | :--: | :-: |
+| `fga_get_model`     | Get the current FGA model.               | ✓ | ✓ |   |
+| `fga_write_model`   | **Write/overwrite the FGA model.**       | ✓ | ✓ | ✓ |
+| `fga_write_tuples`  | Write relationship tuples.               | ✓ | ✓ | ✓ |
+| `fga_delete_tuples` | **Delete relationship tuples.**          | ✓ | ✓ | ✓ |
+| `fga_read_tuples`   | Read relationship tuples.                | ✓ | ✓ | ✓ |
+| `fga_list_users`    | List users with a relation to an object. | ✓ | ✓ | ✓ |
+| `fga_expand`        | Expand a relation into its userset.      | ✓ | ✓ | ✓ |
+| `fga_reset`         | **Reset all FGA data.**                  | ✓ | ✓ |   |
+
+#### GraphQL-only extras
+
+These have no REST / gRPC equivalent and work **over GraphQL only**:
+
+| Method               | Description                          |
+| -------------------- | ------------------------------------ |
+| `admin_signup`       | Bootstrap the first admin.           |
+| `update_env`         | Update server environment/config.    |
+| `generate_jwt_keys`  | Generate a new JWT signing key pair. |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -77,6 +77,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'sdks/authorizer-js/index',
         'sdks/authorizer-js/functions',
+        'sdks/authorizer-js/admin',
       ],
     },
     {
@@ -95,6 +96,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'sdks/authorizer-go/index',
         'sdks/authorizer-go/example',
+        'sdks/authorizer-go/admin',
       ],
     },
     {
@@ -104,6 +106,7 @@ const sidebars: SidebarsConfig = {
         'sdks/authorizer-python/index',
         'sdks/authorizer-python/functions',
         'sdks/authorizer-python/fga',
+        'sdks/authorizer-python/admin',
       ],
     },
     {


### PR DESCRIPTION
Documents the API contract changes in authorizerdev/authorizer#635.

- **rest-api.md** — adds a "no envelope wrapper" note (responses are the bare `AuthResponse`/`User`/`Meta`, byte-identical to GraphQL; addresses the `{"auth":{…}}` confusion); expands the cookie note to all cookie-setting flows and clarifies the REST gateway returns real `Set-Cookie` headers.
- **grpc.md** — adds a response-types note (no per-RPC wrapper) and a cookie-metadata note; drops the stale `authorizer.common.v1` reference now that the proto is a single `authorizer.v1` package.

Pairs with authorizerdev/authorizer#635.