### PR TITLE
docs: fix stale binary paths, update SDK versions, React protocol prop

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,7 +49,7 @@ Please ask as many questions as you need, either directly in the issue or on [Di
    > Note: if you don't have [`make`](https://www.ibm.com/docs/en/aix/7.2?topic=concepts-make-command), you can `cd` into `server` dir and build using the `go build` command
 5. Run binary with required flags:
    ```bash
-   ./build/server \
+   ./authorizer \
      --database-type=sqlite \
      --database-url=test.db \
      --jwt-type=HS256 \

--- a/docs/core/databases.md
+++ b/docs/core/databases.md
@@ -135,7 +135,7 @@ Authorizer supports two session stores:
 Example with Redis:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -42,7 +42,7 @@ This is the most common setup — an app delegates authentication to Authorizer 
 Before any client can use Authorizer for SSO, you need to tell the server which origins and redirect URIs are allowed.
 
 ```bash
-./build/server \
+./authorizer \
   --client-id=my-app \
   --client-secret="$(openssl rand -hex 32)" \
   --allowed-origins=https://app.example.com,http://localhost:3000 \
@@ -313,7 +313,7 @@ Auth0 calls third-party OIDC identity providers **Enterprise Connections**.
 1. **Register Auth0 as an Authorizer client.** In your Authorizer instance, set the `--client-id` and `--client-secret` that Auth0 will use, and include Auth0's callback URL in `--allowed-origins`:
 
    ```bash
-   ./build/server \
+   ./authorizer \
      --client-id=auth0-upstream \
      --client-secret="$(openssl rand -hex 32)" \
      --allowed-origins=https://YOUR_TENANT.auth0.com

--- a/docs/core/rate-limiting.md
+++ b/docs/core/rate-limiting.md
@@ -28,7 +28,7 @@ Every incoming request is tracked by client IP address. Each IP is allowed a sus
 | `--rate-limit-fail-closed` | `false` | If `true`, rate-limit backend errors return **503** instead of allowing the request |
 
 ```bash
-./build/server \
+./authorizer \
   --rate-limit-rps=30 \
   --rate-limit-burst=20
 ```
@@ -38,7 +38,7 @@ Every incoming request is tracked by client IP address. Each IP is allowed a sus
 For high-traffic deployments, increase the limits:
 
 ```bash
-./build/server \
+./authorizer \
   --rate-limit-rps=50 \
   --rate-limit-burst=100
 ```
@@ -46,7 +46,7 @@ For high-traffic deployments, increase the limits:
 For stricter protection (e.g., a small internal deployment):
 
 ```bash
-./build/server \
+./authorizer \
   --rate-limit-rps=5 \
   --rate-limit-burst=10
 ```
@@ -56,7 +56,7 @@ For stricter protection (e.g., a small internal deployment):
 If your infrastructure already provides rate limiting (e.g., API gateway, CDN, or load balancer), you can disable it:
 
 ```bash
-./build/server \
+./authorizer \
   --rate-limit-rps=0
 ```
 
@@ -116,7 +116,7 @@ The `Retry-After: 1` header tells clients to wait at least 1 second before retry
 For deployments with multiple Authorizer replicas, configure Redis to ensure rate limits are shared:
 
 ```bash
-./build/server \
+./authorizer \
   --redis-url=redis://user:pass@redis-host:6379/0 \
   --rate-limit-rps=30 \
   --rate-limit-burst=20
@@ -129,7 +129,7 @@ When `--redis-url` is set, Authorizer automatically uses Redis for both session 
 Redis Cluster is also supported. Provide multiple URLs:
 
 ```bash
-./build/server \
+./authorizer \
   --redis-url="redis://node1:6379,node2:6380,node3:6381"
 ```
 

--- a/docs/core/security.md
+++ b/docs/core/security.md
@@ -23,7 +23,7 @@ batch, you must address these two items before restarting:
    of the secret is your responsibility.
 
    ```bash
-   ./build/server --admin-secret="$(openssl rand -hex 32)" ...
+   ./authorizer --admin-secret="$(openssl rand -hex 32)" ...
    ```
 
 2. **`--trusted-proxies` defaults to none.** Rate limiting, audit logs,
@@ -35,7 +35,7 @@ batch, you must address these two items before restarting:
    real client IP.
 
    ```bash
-   ./build/server \
+   ./authorizer \
      --trusted-proxies=10.0.0.0/8,127.0.0.1/32 \
      ...
    ```
@@ -49,7 +49,7 @@ Everything else in this document is opt-in or already on by default.
 ## Admin authentication
 
 ```bash
-./build/server \
+./authorizer \
   --admin-secret="$(openssl rand -hex 32)" \
   --disable-admin-header-auth=true
 ```
@@ -68,7 +68,7 @@ Everything else in this document is opt-in or already on by default.
 ## Refresh tokens
 
 ```bash
-./build/server --refresh-token-expires-in=2592000
+./authorizer --refresh-token-expires-in=2592000
 ```
 
 - **`--refresh-token-expires-in`** (default `2592000`, 30 days): refresh
@@ -81,7 +81,7 @@ Everything else in this document is opt-in or already on by default.
 ## Trusted proxies
 
 ```bash
-./build/server --trusted-proxies=10.0.0.0/8,127.0.0.1/32
+./authorizer --trusted-proxies=10.0.0.0/8,127.0.0.1/32
 ```
 
 - **`--trusted-proxies`** (default empty, comma-separated CIDRs): list of
@@ -119,7 +119,7 @@ proxy you **must** set this flag, otherwise:
 ### CORS
 
 ```bash
-./build/server --allowed-origins=https://app.example.com,https://admin.example.com
+./authorizer --allowed-origins=https://app.example.com,https://admin.example.com
 ```
 
 - **`--allowed-origins`** (default `*`): comma-separated list of origins
@@ -178,7 +178,7 @@ configurable.
 ## Security response headers
 
 ```bash
-./build/server \
+./authorizer \
   --enable-hsts=true \
   --disable-csp=false
 ```
@@ -342,7 +342,7 @@ failed to decrypt stored TOTP secret; check that --jwt-secret has not changed si
 ## GraphQL hardening
 
 ```bash
-./build/server \
+./authorizer \
   --graphql-max-complexity=300 \
   --graphql-max-depth=15 \
   --graphql-max-aliases=30 \

--- a/docs/core/server-config.md
+++ b/docs/core/server-config.md
@@ -15,7 +15,7 @@ If you are migrating from v1, first skim the high-level [Migration v1 to v2](../
 ## 1. Core flags
 
 ```bash
-./build/server \
+./authorizer \
   --env=production \
   --http-port=8080 \
   --host=0.0.0.0 \
@@ -38,7 +38,7 @@ If you are migrating from v1, first skim the high-level [Migration v1 to v2](../
 ### Database
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=postgres \
   --database-url="postgres://user:pass@host/db" \
   --database-name=authorizer \
@@ -55,7 +55,7 @@ Key flags:
 ### Session / cache
 
 ```bash
-./build/server \
+./authorizer \
   --redis-url=redis://user:pass@redis-host:6379/0
 ```
 
@@ -69,7 +69,7 @@ Key flags:
 These flags replace v1 env such as `CLIENT_ID`, `CLIENT_SECRET`, and app behavior toggles.
 
 ```bash
-./build/server \
+./authorizer \
   --client-id=YOUR_CLIENT_ID \
   --client-secret=YOUR_CLIENT_SECRET \
   --admin-secret=your-admin-secret \
@@ -96,7 +96,7 @@ These flags replace v1 env such as `CLIENT_ID`, `CLIENT_SECRET`, and app behavio
 Organization / UI:
 
 ```bash
-./build/server \
+./authorizer \
   --organization-name="Your Company" \
   --organization-logo="https://your-cdn/logo.png" \
   --enable-login-page=true \
@@ -115,7 +115,7 @@ Organization / UI:
 ### Roles and auth flows
 
 ```bash
-./build/server \
+./authorizer \
   --roles=user,admin \
   --default-roles=user \
   --protected-roles=admin \
@@ -135,7 +135,7 @@ See the [Auth behavior mapping](../migration/v1-to-v2#auth-behavior) for exact c
 ### Cookies
 
 ```bash
-./build/server \
+./authorizer \
   --app-cookie-secure=true \
   --admin-cookie-secure=true
 ```
@@ -147,7 +147,7 @@ Use `true` for HTTPS-only cookies in production.
 ## 5. JWT configuration
 
 ```bash
-./build/server \
+./authorizer \
   --jwt-type=HS256 \
   --jwt-secret=your-jwt-secret \
   --jwt-role-claim=role
@@ -156,7 +156,7 @@ Use `true` for HTTPS-only cookies in production.
 Or for asymmetric keys:
 
 ```bash
-./build/server \
+./authorizer \
   --jwt-type=RS256 \
   --jwt-private-key="$(cat /path/to/private.key)" \
   --jwt-public-key="$(cat /path/to/public.key)"
@@ -182,7 +182,7 @@ In v2, the `_generate_jwt_keys` mutation is deprecated and returns an error; con
 ### SMTP
 
 ```bash
-./build/server \
+./authorizer \
   --smtp-host=smtp.mailprovider.com \
   --smtp-port=587 \
   --smtp-username=user@example.com \
@@ -196,7 +196,7 @@ In v2, the `_generate_jwt_keys` mutation is deprecated and returns an error; con
 ### Twilio (SMS OTP)
 
 ```bash
-./build/server \
+./authorizer \
   --twilio-account-sid=AC... \
   --twilio-api-key=... \
   --twilio-api-secret=... \
@@ -210,7 +210,7 @@ In v2, the `_generate_jwt_keys` mutation is deprecated and returns an error; con
 Each provider uses its own set of flags:
 
 ```bash
-./build/server \
+./authorizer \
   --google-client-id=... \
   --google-client-secret=... \
   --google-scopes="openid,email,profile" \
@@ -235,7 +235,7 @@ Other supported providers follow the same pattern:
 ## 8. Rate limiting
 
 ```bash
-./build/server \
+./authorizer \
   --rate-limit-rps=30 \
   --rate-limit-burst=20 \
   --rate-limit-fail-closed=false
@@ -254,7 +254,7 @@ Rate limiting is always enabled by default. When `--redis-url` is set, limits ar
 New in v2:
 
 ```bash
-./build/server \
+./authorizer \
   --disable-admin-header-auth=true \
   --enable-graphql-introspection=false \
   --graphql-max-complexity=300 \
@@ -279,7 +279,7 @@ metric, labelled by limit kind. See
 ### Authorization (FGA)
 
 ```bash
-./build/server \
+./authorizer \
   --fga-store=postgres \
   --fga-store-url="postgres://user:pass@host/db" \
   --include-permissions-in-token=false \
@@ -298,7 +298,7 @@ Authorizer ships an embedded **OpenFGA** (ReBAC) engine. It is enabled by defaul
 ## 9. Security headers
 
 ```bash
-./build/server \
+./authorizer \
   --enable-hsts=true \
   --disable-csp=false
 ```
@@ -329,7 +329,7 @@ See the dedicated [Security Hardening](./security) page for:
 To list all available flags and their defaults, run:
 
 ```bash
-./build/server --help
+./authorizer --help
 ```
 
 For a v1 to v2 mapping table, see [Configuration Mapping](../migration/v1-to-v2#3-configuration-mapping-v1-env--v1-behavior-to-v2-cli-flags).

--- a/docs/deployment/alibaba-cloud.md
+++ b/docs/deployment/alibaba-cloud.md
@@ -26,7 +26,7 @@ An [Alibaba Cloud account](https://www.alibabacloud.com/).
 After deployment, configure the required v2 variables in your instance:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/deployment/binary.md
+++ b/docs/deployment/binary.md
@@ -23,13 +23,13 @@ You can either:
 git clone https://github.com/authorizerdev/authorizer.git
 cd authorizer
 
-go build -o build/server .
+go build -o build/authorizer .
 ```
 
 After extraction or build, you should have:
 
 ```bash
-./build/server
+./authorizer
 ```
 
 ---
@@ -45,7 +45,7 @@ At minimum, Authorizer v2 needs:
 Example for SQLite:
 
 ```bash
-./build/server \
+./authorizer \
   --env=production \
   --http-port=8080 \
   --database-type=sqlite \
@@ -77,7 +77,7 @@ Description=Authorizer v2
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart=/path_to_authorizer_parent_folder/authorizer/build/server \
+ExecStart=/path_to_authorizer_parent_folder/authorizer/build/authorizer \
   --env=production \
   --http-port=8080 \
   --database-type=postgres \

--- a/docs/deployment/easypanel.md
+++ b/docs/deployment/easypanel.md
@@ -22,7 +22,7 @@ EasyPanel provides a template for deploying Authorizer. Deploy using the templat
 After deployment, update the start command to include the required v2 CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -67,7 +67,7 @@ image = "quay.io/authorizer/authorizer:latest"
 
 [experimental]
 cmd = [
-  "./build/server",
+  "./authorizer",
   "--database-type=postgres",
   "--database-url=postgres://user:pass@localhost:5432/authorizer",
   "--jwt-type=HS256",

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -52,7 +52,7 @@ Use `REDIS_URL` for shared sessions and rate limits across dynos ([rate limiting
 Update the Procfile or startup command to pass CLI flags:
 
 ```
-web: ./build/server --database-type=$DATABASE_TYPE --database-url=$DATABASE_URL --jwt-type=$JWT_TYPE --jwt-secret=$JWT_SECRET --admin-secret=$ADMIN_SECRET --client-id=$CLIENT_ID --client-secret=$CLIENT_SECRET
+web: ./authorizer --database-type=$DATABASE_TYPE --database-url=$DATABASE_URL --jwt-type=$JWT_TYPE --jwt-secret=$JWT_SECRET --admin-secret=$ADMIN_SECRET --client-id=$CLIENT_ID --client-secret=$CLIENT_SECRET
 ```
 
 ---

--- a/docs/deployment/koyeb.md
+++ b/docs/deployment/koyeb.md
@@ -52,7 +52,7 @@ Add the following environment variables:
 Update the start command to pass CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=$DATABASE_TYPE \
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -192,4 +192,4 @@ You no longer update server config via `_update_env` or dashboard; those are dep
 For a full list of available flags, see:
 
 - [Server Configuration (v2)](../core/server-config)
-- `./build/server --help` in the container image
+- `./authorizer --help` in the container image

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -54,7 +54,7 @@ Set `REDIS_URL` when you use multiple instances so sessions and rate limits stay
 Update the start command to pass CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=$DATABASE_TYPE \
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -58,7 +58,7 @@ See [Metrics & monitoring](../core/metrics-monitoring) and [Rate limiting](../co
 Update the start command to pass CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=$DATABASE_TYPE \
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -42,9 +42,9 @@ All examples below use these required variables. Replace with your own values fo
 git clone https://github.com/authorizerdev/authorizer.git
 cd authorizer
 
-go build -o build/server .
+go build -o build/authorizer .
 
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \
@@ -111,7 +111,7 @@ tar -zxf AUTHORIZER_VERSION -c authorizer
 cd authorizer
 
 # Run with required flags
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \
@@ -121,7 +121,7 @@ cd authorizer
   --client-secret=secret
 ```
 
-> For Mac users, grant permission: `xattr -d com.apple.quarantine build/server`
+> For Mac users, grant permission: `xattr -d com.apple.quarantine build/authorizer`
 
 See [Binary deployment](../deployment/binary) for systemd service setup.
 
@@ -164,7 +164,7 @@ After starting the server, open:
 For a quick local dev setup:
 
 ```bash
-./build/server \
+./authorizer \
   --env=development \
   --http-port=8080 \
   --database-type=sqlite \

--- a/docs/integrations/gatsbyjs.md
+++ b/docs/integrations/gatsbyjs.md
@@ -22,7 +22,7 @@ For more information check [docs](https://docs.authorizer.dev/getting-started/)
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/integrations/hasura.md
+++ b/docs/integrations/hasura.md
@@ -28,7 +28,7 @@ You can also deploy Authorizer instance using
 
 > **Note:** If you are trying out with one click deployment options like railway then template is configured in a way that it will also deploy postgres + redis for you. For other deployment options, start the server with the required CLI flags:
 > ```bash
-> ./build/server --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --admin-secret=admin --client-id=123456 --client-secret=secret
+> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --admin-secret=admin --client-id=123456 --client-secret=secret
 > ```
 > You can also configure `--redis-url` to have persisted sessions. For more information check [Server Configuration](/core/server-config).
 
@@ -39,7 +39,7 @@ In case of Hasura, we need to have database type as `postgres` / `mysql` or the 
 Configure your Authorizer instance using CLI flags at startup. In v2, all configuration is passed via CLI flags (no dashboard-based env configuration). For example:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=postgres \
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -27,7 +27,7 @@ For more information check [docs](https://docs.authorizer.dev/getting-started/)
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -47,7 +47,7 @@ Authorizer v2 focuses on simpler, more secure configuration and a cleaner operat
 ### Quick Start
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \
@@ -96,17 +96,17 @@ See [Databases](./core/databases) for connection string formats.
 
 ### Frontend SDKs
 
-- [JavaScript / TypeScript](https://github.com/authorizerdev/authorizer-js) (v3 for Authorizer v2)
-- [React](https://github.com/authorizerdev/authorizer-react) (v2 for Authorizer v2)
+- [JavaScript / TypeScript](https://github.com/authorizerdev/authorizer-js) — v3.2.1; user + admin client; GraphQL + REST protocols
+- [React](https://github.com/authorizerdev/authorizer-react) — v2.1.0; `protocol` prop; pre-built login/signup/MFA components
 - [Vue](https://github.com/authorizerdev/authorizer-vue)
 - [Svelte](https://github.com/authorizerdev/authorizer-svelte)
-- [Flutter](https://github.com/nickolasgomez/authorizer-flutter-sdk)
+- [Flutter](https://github.com/nickolasgomez/authorizer-flutter-sdk) (community)
 
 ### Backend SDKs
 
-- [Golang](https://github.com/authorizerdev/authorizer-go)
-- [Python](https://github.com/authorizerdev/authorizer-python) (`pip install authorizer-py`)
-- [Node.js](https://github.com/authorizerdev/authorizer-js) (same package, works server-side)
+- [Go](https://github.com/authorizerdev/authorizer-go) — user + admin client; protocol selection (gRPC / REST / GraphQL); FGA helpers
+- [Python](https://github.com/authorizerdev/authorizer-python) — v0.2.0; sync + async; admin API (`pip install authorizer-py`)
+- [Node.js](https://github.com/authorizerdev/authorizer-js) — same package as the frontend SDK, works server-side
 
 See the [SDK reference](./sdks/authorizer-js) for usage docs.
 
@@ -121,3 +121,4 @@ See the [SDK reference](./sdks/authorizer-js) for usage docs.
 - WordPress plugin
 - AMI / Digital Ocean Droplet
 - Azure deployment
+- Vue / Svelte admin client and protocol parity with authorizer-js

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -87,7 +87,7 @@ export DATABASE_TYPE=sqlite
 export DATABASE_URL=data.db
 export CLIENT_ID=...
 export CLIENT_SECRET=...
-./build/server
+./authorizer
 ```
 
 Or configure via dashboard after first run.
@@ -97,7 +97,7 @@ Or configure via dashboard after first run.
 Pass all config as **CLI arguments** when starting the server:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=data.db \
   --client-id=YOUR_CLIENT_ID \
@@ -125,7 +125,7 @@ To keep using env vars in your deployment:
 - **Option A:** Set env vars in your platform (Docker, K8s, Railway, etc.) and pass them into the process as arguments via a wrapper script or `envsubst`:
 
   ```bash
-  ./build/server \
+  ./authorizer \
     --database-type="$DATABASE_TYPE" \
     --database-url="$DATABASE_URL" \
     --client-id="$CLIENT_ID" \
@@ -144,7 +144,7 @@ docker run -p 8080:8080 \
   -e CLIENT_ID=... \
   -e CLIENT_SECRET=... \
   your-authorizer-image \
-  ./build/server \
+  ./authorizer \
     --database-type="$DATABASE_TYPE" \
     --database-url="$DATABASE_URL" \
     --client-id="$CLIENT_ID" \
@@ -344,7 +344,7 @@ The following flags are **new in v2** and help harden your deployment:
 To see all flags and defaults:
 
 ```bash
-./build/server --help
+./authorizer --help
 ```
 
 ### Breaking changes — April 2026 security batch
@@ -370,7 +370,7 @@ restarting. The strength of the secret is your responsibility — the
 server only enforces non-emptiness.
 
 ```bash
-./build/server --admin-secret="$(openssl rand -hex 32)" ...
+./authorizer --admin-secret="$(openssl rand -hex 32)" ...
 ```
 
 #### `--trusted-proxies` defaults to none
@@ -393,13 +393,13 @@ its first burst:
 
 ```bash
 # Behind nginx on the same host
-./build/server --trusted-proxies=127.0.0.1/32,::1/128 ...
+./authorizer --trusted-proxies=127.0.0.1/32,::1/128 ...
 
 # Inside a Kubernetes cluster
-./build/server --trusted-proxies=10.0.0.0/8 ...
+./authorizer --trusted-proxies=10.0.0.0/8 ...
 
 # Behind Cloudflare
-./build/server --trusted-proxies=$(cat cloudflare-ips.txt | paste -sd, -) ...
+./authorizer --trusted-proxies=$(cat cloudflare-ips.txt | paste -sd, -) ...
 ```
 
 See the new [Security Hardening](../core/security#trusted-proxies) page
@@ -537,7 +537,7 @@ If your app or dashboard calls `_update_env`, `_admin_signup`, or `_generate_jwt
 Example:
 
 ```dockerfile
-ENTRYPOINT [ "./build/server" ]
+ENTRYPOINT [ "./authorizer" ]
 CMD []
 ```
 
@@ -552,7 +552,7 @@ docker run -p 8080:8080 your-image \
   --admin-secret=...
 ```
 
-Or use a script inside the image that maps env to flags and then runs `./build/server ...`.
+Or use a script inside the image that maps env to flags and then runs `./authorizer ...`.
 
 ---
 

--- a/docs/sdks/authorizer-js/index.md
+++ b/docs/sdks/authorizer-js/index.md
@@ -31,7 +31,7 @@ For more information check [docs](https://docs.authorizer.dev/getting-started/)
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/sdks/authorizer-python/index.md
+++ b/docs/sdks/authorizer-python/index.md
@@ -33,7 +33,7 @@ For more information check the [deployment docs](https://docs.authorizer.dev/dep
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/sdks/authorizer-react/components.md
+++ b/docs/sdks/authorizer-react/components.md
@@ -27,11 +27,16 @@ title: Components
 
 - `config`: Object to configure the `authorizer` backend URL and redirect URL. It accepts JSON object with following keys
 
-| Key                     | Type       | Description                                                                                                                | Required |
-| ----------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `authorizerURL`         | `string`   | Authorizer backend URL                                                                                                     | `true`   |
-| `redirectURL`           | `string`   | Frontend application URL or the page where you want to redirect user post login. Default value is `window.location.origin` | `true`   |
-| `onStateChangeCallback` | `function` | [optional] Async callback that is called whenever context state information changes.                                       | `false`  |
+| Key                     | Type                              | Description                                                                                                                          | Required |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `authorizerURL`         | `string`                          | Authorizer backend URL                                                                                                               | `true`   |
+| `redirectURL`           | `string`                          | Frontend application URL or the page where you want to redirect user post login. Default value is `window.location.origin`           | `true`   |
+| `clientID`              | `string`                          | Your client identifier (the value of `--client-id` flag used when starting the server)                                              | `false`  |
+| `protocol`              | `'graphql' \| 'rest'`             | Wire transport for API calls. Default is `'graphql'`. Use `'rest'` to route calls through the typed REST endpoints instead.          | `false`  |
+| `extraHeaders`          | `Record<string, string>`          | Optional headers added to every SDK request (e.g. `{ 'Origin': 'https://your-app.com' }`)                                           | `false`  |
+| `onStateChangeCallback` | `function`                        | Async callback that is called whenever context state information changes.                                                            | `false`  |
+
+> **Note:** `'grpc'` is not supported in `authorizer-react` because browsers cannot speak raw gRPC. Use `'graphql'` (default) or `'rest'`.
 
 ### Sample Usage
 
@@ -44,10 +49,12 @@ const App = () => {
       config={{
         authorizerURL: 'http://localhost:8080',
         redirectURL: window.location.origin,
+        clientID: 'YOUR_CLIENT_ID',
+        protocol: 'graphql', // or 'rest'
       }}
       onStateChangeCallback={async (newState) => {}}
     >
-      // REST of the components goes here.
+      {/* rest of your components */}
     </AuthorizerProvider>
   )
 }

--- a/docs/sdks/authorizer-react/index.md
+++ b/docs/sdks/authorizer-react/index.md
@@ -26,7 +26,7 @@ For more information check [docs](https://docs.authorizer.dev/getting-started/)
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \

--- a/docs/sdks/authorizer-svelte/index.md
+++ b/docs/sdks/authorizer-svelte/index.md
@@ -26,7 +26,7 @@ For more information check [docs](https://docs.authorizer.dev/getting-started/)
 Start your Authorizer instance with the required CLI flags:
 
 ```bash
-./build/server \
+./authorizer \
   --database-type=sqlite \
   --database-url=test.db \
   --jwt-type=HS256 \


### PR DESCRIPTION
## Summary

- Fix `./build/server` → `./authorizer` across all 26 affected docs files (getting-started, deployment, core, SDK, integration, migration docs) — the binary was renamed in v2
- Update `introduction.md` SDK listing with current versions (JS v3.2.1, React v2.1.0, Go with admin + protocol selection, Python v0.2.0); trim Roadmap to remaining items only
- Add `protocol`, `clientID`, and `extraHeaders` props to `AuthorizerProvider` docs in `authorizer-react/components.md`; note gRPC is not supported in browser SDKs

## Test plan

- [ ] Verify all code blocks referencing the binary now use `./authorizer`
- [ ] Confirm `AuthorizerProvider` prop table renders correctly
- [ ] Confirm introduction SDK section shows correct versions