### PR TITLE
chore: import server-repo specs, merge unique OIDC content

### DIFF
--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -26,7 +26,7 @@ This page is the one-stop reference for every endpoint, parameter, and integrati
 | RFC 6750 (Bearer Token)               | Implemented   | `WWW-Authenticate` on 401                                          |
 | RFC 7009 (Token Revocation)           | Implemented   | Returns 200 for invalid tokens                                     |
 | RFC 7517 (JWK)                        | Implemented   | RSA, ECDSA, HMAC; manual multi-key rotation                        |
-| RFC 7636 (PKCE)                       | Implemented   | S256 method; required for authorization code flow                  |
+| RFC 7636 (PKCE)                       | Implemented   | `S256` and `plain` methods; defaults to `plain` when the method is omitted (§4.2) |
 | RFC 7662 (Token Introspection)        | Implemented   | Non-disclosure for inactive tokens                                 |
 
 **Not yet implemented** (tracked for future releases): RFC 7591 dynamic client registration, RFC 9101 JAR / Request Object, OIDC Session Management iframe, front-channel logout, automated time-based key rotation.
@@ -335,7 +335,7 @@ Auth0 calls third-party OIDC identity providers **Enterprise Connections**.
 
 4. **Test.** Open an Auth0 Universal Login page — you should see a new button labeled `authorizer` (or whatever you named the connection). Clicking it redirects through Authorizer and lands back on your Auth0 app as a normal Auth0 user.
 
-**What Auth0 does under the hood:** it calls Authorizer's `/authorize` endpoint with a code-flow request, exchanges the code at `/oauth/token`, verifies the ID token via `/.well-known/jwks.json`, and calls `/userinfo` to populate the Auth0 user profile. All of these endpoints are implemented by Authorizer.
+**What Auth0 does under the hood:** it calls Authorizer's `/authorize` endpoint with a code-flow request, exchanges the code at `/oauth/token`, verifies the ID token via `/.well-known/jwks.json`, and calls `/userinfo` to populate the Auth0 user profile. All of these endpoints are implemented by Authorizer. Three Auth0 quirks Authorizer handles for you: Auth0 always sends a `nonce` (even for the code flow, where OIDC makes it optional) and validates it against the ID token; it uses `response_mode=form_post` for the authorization response; and it may send a `code_challenge` without `code_challenge_method`, in which case Authorizer defaults to `plain` per RFC 7636 §4.2.
 
 ### Okta: Add Authorizer as an Identity Provider
 
@@ -409,9 +409,9 @@ Returns metadata so clients can auto-configure themselves.
 | `grant_types_supported`                               | `["authorization_code", "refresh_token", "implicit"]`                                |
 | `scopes_supported`                                    | `["openid", "email", "profile", "offline_access"]`                                   |
 | `response_modes_supported`                            | `["query", "fragment", "form_post", "web_message"]`                                  |
-| `code_challenge_methods_supported`                    | `["S256"]`                                                                           |
+| `code_challenge_methods_supported`                    | `["S256", "plain"]`                                                                  |
 | `id_token_signing_alg_values_supported`               | Includes configured `--jwt-type` and always `RS256`                                  |
-| `token_endpoint_auth_methods_supported`               | `["client_secret_basic", "client_secret_post"]`                                      |
+| `token_endpoint_auth_methods_supported`               | `["client_secret_basic", "client_secret_post", "none", "private_key_jwt"]` (`none` = public client with PKCE) |
 | `introspection_endpoint_auth_methods_supported`       | `["client_secret_basic", "client_secret_post"]`                                      |
 | `revocation_endpoint_auth_methods_supported`          | `["client_secret_basic", "client_secret_post"]`                                      |
 | `claims_supported`                                    | Includes `sub`, `iss`, `aud`, `exp`, `iat`, `auth_time`, `amr`, `acr`, `at_hash`, `c_hash`, `nonce`, `email`, `email_verified`, `given_name`, `family_name`, profile claims |
@@ -440,7 +440,7 @@ Supported flows: Authorization Code (with PKCE), Implicit, Hybrid.
 | `scope`                  | No                          | Space-separated. Default: `openid profile email`                                      |
 | `response_mode`          | No                          | `query`, `fragment`, `form_post`, `web_message`. Hybrid flows forbid `query`          |
 | `code_challenge`         | Yes, when `code` is in type | PKCE challenge: `BASE64URL(SHA256(code_verifier))`                                    |
-| `code_challenge_method`  | No                          | Only `S256` is supported; defaults to `S256`                                          |
+| `code_challenge_method`  | No                          | `S256` or `plain`; defaults to `plain` when omitted, per RFC 7636 §4.2                |
 | `nonce`                  | Recommended                 | Binds ID token to session; required per OIDC when `response_type` includes `id_token` |
 | `prompt`                 | No                          | `none`, `login`, `consent`, `select_account` (last two are parsed but no-op)          |
 | `max_age`                | No                          | Seconds; `0` forces re-auth; positive values force re-auth if session is older        |
@@ -479,6 +479,26 @@ GET /authorize?
 
 The response fragment contains **both** `code=` and `id_token=` in a single round trip.
 
+#### Nonce handling
+
+The `nonce` prevents ID token replay: the client sends a random value on `/authorize` and must get the same value back as the `nonce` claim in the ID token.
+
+- **Code flow:** OIDC Core makes `nonce` optional here, but enterprise RPs (Auth0, Okta, Keycloak) always send and validate it. Authorizer stores the nonce with the authorization code — including across the login UI round-trip — and embeds it in the ID token issued at `/oauth/token`.
+- **Implicit flow** (`response_type=id_token` or `id_token token`): `nonce` is **required** per OIDC Core §3.2.2.1; requests without it are rejected with `invalid_request`.
+
+#### Response modes
+
+| Mode          | Delivery                                       | Notes                                              |
+|---------------|------------------------------------------------|-----------------------------------------------------|
+| `query`       | Redirect with params in the query string       | Only for the `code` flow — tokens never go in URLs; forbidden for hybrid flows |
+| `fragment`    | Redirect with params in the URL fragment       | Default for implicit / hybrid flows                 |
+| `form_post`   | Auto-submitting HTML form `POST` to the RP     | Used by Auth0 for Enterprise OIDC connections       |
+| `web_message` | `window.postMessage()` to the RP               | For SPA integrations                                |
+
+Error responses (e.g. `login_required` from `prompt=none`) are delivered via the same configured `response_mode`.
+
+For `form_post`, Authorizer serves the auto-submitting form with a dedicated `Content-Security-Policy` (nonce-based `script-src`, relaxed `form-action`) so the browser allows the form to POST to the RP's `redirect_uri`. If a reverse proxy in front of Authorizer injects its own CSP header, it can break `form_post` — see [Common Issues](#common-issues).
+
 ### Token Endpoint
 
 **Endpoint:** `POST /oauth/token`
@@ -499,7 +519,9 @@ Exchanges an authorization code or refresh token for access / ID tokens.
 | `client_id`     | Yes      | Your client ID                                          |
 | `client_secret` | Yes\*    | Required if `code_verifier` is not provided             |
 
-\*Either `code_verifier` or `client_secret` is required. Client authentication may also be sent via HTTP Basic Auth.
+\*Either `code_verifier` or `client_secret` is required. Client authentication may be sent as HTTP Basic (`client_secret_basic`), in the form body (`client_secret_post`), or omitted entirely for public clients using PKCE (`none`).
+
+Authorization codes expire after **10 minutes** (RFC 6749 §4.1.2 recommendation) and are single-use.
 
 **Refresh Token grant:**
 
@@ -728,6 +750,10 @@ const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(hash)))
 printf '%s' "$CODE_VERIFIER" | openssl dgst -binary -sha256 | openssl base64 | tr -d '=' | tr '/+' '_-'
 ```
 
+:::note plain method
+If `code_challenge_method` is omitted, Authorizer defaults to `plain` per RFC 7636 §4.2 — the verifier is compared directly to the challenge, no hashing. Always send `code_challenge_method=S256` explicitly; `plain` exists only for spec compliance with clients that can't compute SHA-256.
+:::
+
 ### 3. Send it on `/authorize`
 
 ```
@@ -949,6 +975,8 @@ For pre-production validation, run a full OIDC conformance suite:
 | Back-channel logout never fires                   | `--backchannel-logout-uri` not set, or receiver unreachable within 5 seconds                       |
 | Auth0 Enterprise OIDC connection can't discover   | Wrong Issuer URL — must be exactly `https://your-authorizer.example` (no trailing slash, no path)  |
 | `redirect_uri` rejected                           | Not in `--allowed-origins`. The debug-level log message names the exact URI that was rejected      |
+| RP reports "unexpected ID Token nonce claim value" | The `nonce` sent to `/authorize` didn't round-trip into the ID token. A custom login UI must forward `nonce` (and the PKCE params) back to `/authorize` after authentication |
+| `form_post` blocked: "sending form data violates Content Security Policy" | A reverse proxy in front of Authorizer is injecting its own CSP header, overriding the `form_post` CSP Authorizer sets |
 
 ## Debugging Tips
 

--- a/specs/GRPC_REST_API_SPEC.md
+++ b/specs/GRPC_REST_API_SPEC.md
@@ -1,0 +1,586 @@
+# Specification: gRPC & REST API with gRPC-Gateway
+
+This document specifies the architecture and mapping for exposing Authorizer's public APIs via gRPC and a generated RESTful layer using `grpc-gateway`.
+
+## 1. Architecture Overview
+
+Authorizer uses a single-source-of-truth Protobuf definition to generate:
+1.  **gRPC Service**: For high-performance, typed backend-to-backend communication.
+2.  **RESTful API**: Via `grpc-gateway`, maintaining backward compatibility and ease of use for web/mobile clients.
+3.  **TypeScript Clients**: Via `ts-proto`, providing type-safe API consumption out of the box.
+
+### Package & Versioning
+- **Package**: `authorizer.v1`
+- **Directory Structure**: `proto/authorizer/v1/`
+- **API Versioning**: Hardcoded in HTTP paths as `/v1/...` and tracked via Protobuf package versioning.
+
+### REST Naming Conventions (Stripe-aligned)
+
+Authorizer's REST surface follows the **Stripe "gold standard" REST conventions**. Stripe is widely regarded as the benchmark for developer-facing REST API design, and aligning with it keeps the surface consistent and unsurprising:
+
+1. **`snake_case` everywhere — paths, query parameters, and JSON bodies.**
+   Multi-word path segments use underscores, e.g. `/v1/magic_link_login`,
+   `/v1/verify_email`, `/v1/validate_jwt_token`. This mirrors Stripe's own
+   paths (`/v1/payment_intents`, `/v1/setup_intents`) and, critically, keeps a
+   **single** naming style across the entire product: the path segment, the
+   gRPC method identifier, the GraphQL operation name, and every JSON field are
+   all `snake_case`. (The gateway sets `UseProtoNames=true` so response bodies
+   stay `snake_case` rather than protobuf-default `camelCase`.)
+
+   > We deliberately do **not** use `kebab-case` paths. While some guides
+   > (Microsoft, Google AIP) and Keycloak prefer hyphens, mixing hyphenated
+   > paths with `snake_case` bodies/operations would introduce a second naming
+   > convention. Internal consistency wins; Stripe and Auth0
+   > (`/dbconnections/change_password`) set the precedent.
+
+2. **HTTP method reflects effect.** `GET` is reserved for safe, side-effect-free
+   reads (`meta`, `profile`, `permissions`). Anything that mutates server state
+   — including `logout` (it clears the session and is audit-logged) — uses
+   `POST`. A mutating `GET` would violate RFC 9110 §9.2.1 and expose the
+   endpoint to CSRF.
+
+3. **Path prefix `/v1`** (not `/api/v1`) — the version is the first segment,
+   matching Stripe's `/v1/...`.
+
+4. **Stable, snake_case error envelope** on every `/v1` endpoint:
+
+   ```json
+   { "code": "invalid_argument", "message": "email or phone number is required" }
+   ```
+
+   The HTTP status is derived from the gRPC status code
+   (`invalid_argument`→400, `unauthenticated`→401, `permission_denied`→403,
+   `not_found`→404, `failed_precondition`→400, `internal`→500). The service
+   layer classifies each error with a transport-neutral `ErrorKind`
+   (`internal/service/errors.go`); the gRPC `ErrorMap` interceptor turns that
+   into a status code, and grpc-gateway maps the code to the HTTP status.
+
+### Ecosystem Tooling
+- **`buf`**: Managed build system for Protobuf.
+- **`protoc-gen-grpc-gateway`**: Generates the reverse proxy from gRPC to REST.
+- **`protoc-gen-openapiv2`**: Generates Swagger/OpenAPI documentation.
+- **`protoc-gen-ts_proto`**: Generates the TypeScript client.
+- **`protovalidate`**: High-performance validation rules using Common Expression Language (CEL).
+
+---
+
+## 2. API Mapping (Public Surface)
+
+All public GraphQL queries and mutations are mapped to RPC methods. Terminologies are preserved from the GraphQL schema.
+
+### 2.1. Authentication Service (`authorizer.v1.AuthorizerService`)
+
+Paths are `snake_case` under `/v1` (see "REST Naming Conventions" above). The
+gRPC method name is the `PascalCase` form of the same identifier.
+
+| RPC Method | GraphQL Equivalent | HTTP Path | Permissions |
+| :--- | :--- | :--- | :--- |
+| `Signup` | `signup` | `POST /v1/signup` | Public |
+| `Login` | `login` | `POST /v1/login` | Public |
+| `MagicLinkLogin` | `magic_link_login` | `POST /v1/magic_link_login` | Public |
+| `Logout` | `logout` | `POST /v1/logout` | Authenticated |
+| `VerifyEmail` | `verify_email` | `POST /v1/verify_email` | Public |
+| `ResendVerifyEmail` | `resend_verify_email` | `POST /v1/resend_verify_email` | Public |
+| `ForgotPassword` | `forgot_password` | `POST /v1/forgot_password` | Public |
+| `ResetPassword` | `reset_password` | `POST /v1/reset_password` | Public |
+| `VerifyOtp` | `verify_otp` | `POST /v1/verify_otp` | Public |
+| `ResendOtp` | `resend_otp` | `POST /v1/resend_otp` | Public |
+| `Revoke` | `revoke` | `POST /v1/revoke` | Authenticated |
+| `UpdateProfile` | `update_profile` | `POST /v1/update_profile` | Authenticated |
+| `DeactivateAccount` | `deactivate_account` | `POST /v1/deactivate_account` | Authenticated |
+| `Meta` | `meta` | `GET /v1/meta` | Public |
+| `Session` | `session` | `POST /v1/session` | Authenticated |
+| `Profile` | `profile` | `GET /v1/profile` | Authenticated |
+| `ValidateJwtToken` | `validate_jwt_token` | `POST /v1/validate_jwt_token` | Public/Service |
+| `ValidateSession` | `validate_session` | `POST /v1/validate_session` | Public/Service |
+| `CheckPermissions` | `check_permissions` | `POST /v1/check_permissions` | Authenticated |
+| `ListPermissions` | `list_permissions` | `POST /v1/list_permissions` | Authenticated |
+
+### 2.2. OIDC & OAuth2 REST Endpoints
+The following endpoints remain as pure HTTP handlers to comply with strict OIDC/OAuth2 protocol requirements (redirects, form-encoding):
+- `GET /.well-known/openid-configuration`
+- `GET /.well-known/jwks.json`
+- `GET /authorize`
+- `GET /userinfo`
+- `POST /oauth/token`
+- `POST /oauth/revoke`
+- `POST /oauth/introspect`
+- `GET /oauth_login/:oauth_provider`
+
+### 2.3. Authentication for gRPC Clients
+
+gRPC has no native cookie jar. Callers authenticate by attaching **metadata**
+(key/value pairs on the RPC context). The server maps this metadata into the
+same `RequestMetadata` the GraphQL and REST paths use
+(`internal/grpcsrv/transport/grpc_metadata.go`).
+
+#### User authentication
+
+Authenticated public RPCs accept either:
+
+| Mechanism | gRPC metadata key | Value |
+| :--- | :--- | :--- |
+| Bearer access token | `authorization` | `Bearer <access_token>` |
+| Session cookie | `cookie` | `authorizer_session=<value>` (semicolon-separated if multiple) |
+
+Over REST via grpc-gateway, the browser's cookies and `Authorization` header
+are forwarded automatically (`grpcgateway-cookie`, `grpcgateway-authorization`).
+Pure gRPC clients must set these metadata keys explicitly.
+
+#### Admin authentication
+
+All `AuthorizerAdminService` RPCs except `AdminLogin` require super-admin auth:
+
+| Mechanism | gRPC metadata key | Value |
+| :--- | :--- | :--- |
+| Admin secret header | `x-authorizer-admin-secret` | The configured admin secret |
+| Admin session cookie | `cookie` | `authorizer_admin_session=<value>` |
+
+`AdminLogin` is public — it validates the admin secret in the request body and
+returns an admin session cookie via response metadata (`Set-Cookie` trailers).
+
+#### Pure gRPC: `x-authorizer-url` is required
+
+REST callers inherit the host from the HTTP request. Pure gRPC callers **must**
+set `x-authorizer-url` to the Authorizer instance's public base URL (e.g.
+`https://auth.example.com`). The server uses this value to:
+
+- Resolve JWT issuer/audience during token validation
+- Mint tokens with the correct issuer claim
+- Build redirect URLs and cookie domain scoping
+
+When absent, the server falls back to the gRPC `:authority` pseudo-header
+(`http://<host>`), which is usually wrong behind TLS terminators or when the
+gRPC port differs from the public URL. Always set `x-authorizer-url` in
+production gRPC clients.
+
+#### Token validation RPCs: credentials in the request body
+
+`ValidateJwtToken` and `ValidateSession` are **public** service-to-service
+RPCs. The token or session cookie to validate is passed in the **request
+message**, not in metadata:
+
+- `ValidateJwtTokenRequest.token` + `token_type` — the JWT to inspect
+- `ValidateSessionRequest.cookie` — the session cookie value to inspect
+
+These RPCs do not require (and do not read) `authorization` metadata. Callers
+may still attach `x-authorizer-url` so issuer checks resolve correctly.
+
+#### Cookie vs bearer matrix (authenticated public RPCs)
+
+| RPC | Session cookie | Bearer token | Notes |
+| :--- | :---: | :---: | :--- |
+| `Session` | Required | — | Cookie only (`cookie.GetSession`); bearer is ignored |
+| `Profile` | ✓ | ✓ | Either mechanism |
+| `UpdateProfile` | ✓ | ✓ | Either mechanism |
+| `Logout` | ✓ | ✓ | Either mechanism |
+| `DeactivateAccount` | ✓ | ✓ | Either mechanism |
+| `CheckPermissions` | ✓ | ✓ | Either mechanism; subject defaults to caller |
+| `ListPermissions` | ✓ | ✓ | Either mechanism; subject defaults to caller |
+| `Revoke` | — | — | `refresh_token` in request body only |
+
+All other public RPCs (`Signup`, `Login`, `Meta`, `ValidateJwtToken`,
+`ValidateSession`, password-reset flows, etc.) are unauthenticated entry points.
+
+#### TLS in production
+
+Development and integration tests may use plaintext gRPC (`insecure` credentials).
+**Production gRPC clients must use TLS** (`grpc.WithTransportCredentials`) against
+the Authorizer gRPC listener. Bearer tokens and session cookies must never
+traverse an unencrypted channel outside local development.
+
+#### Client helpers
+
+Go callers should use the helpers in
+[`internal/grpcsrv/client`](https://github.com/authorizerdev/authorizer/tree/main/internal/grpcsrv/client)
+(`WithBearerToken`, `WithAuthorizerURL`, `WithAdminSecret`, `WithCookies`) to attach
+metadata consistently:
+
+```go
+import grpcclient "github.com/authorizerdev/authorizer/internal/grpcsrv/client"
+
+ctx = grpcclient.WithBearerToken(ctx, accessToken)
+ctx = grpcclient.WithAuthorizerURL(ctx, "https://auth.example.com")
+resp, err := client.Profile(ctx, &authorizerv1.ProfileRequest{})
+```
+
+---
+
+## 3. Required Relations: Fine-Grained Authorization Gates
+
+The `Session`, `ValidateJwtToken`, and `ValidateSession` RPCs accept an optional `required_relations` field that gates the response on fine-grained authorization checks. When provided, each (relation, object) pair is evaluated against the authenticated subject with AND semantics:
+
+**Example**: Session RPC with required relations
+
+```json
+{
+  "roles": ["admin"],
+  "scope": ["read:profile"],
+  "required_relations": [
+    {
+      "relation": "can_manage",
+      "object": "organization:1"
+    },
+    {
+      "relation": "can_edit",
+      "object": "workspace:42"
+    }
+  ]
+}
+```
+
+The session is returned only if the caller can both `can_manage` the organization AND `can_edit` the workspace. If any check fails, the RPC returns `permission_denied`. This is fail-closed behavior.
+
+**When to Use**:
+- Implementing conditional access policies.
+- Gating session establishment on resource-specific permissions.
+- Building fine-grained authorization directly into token validation.
+
+**Compatibility**:
+- If fine-grained authorization is not enabled (`--fga-store` not set), providing `required_relations` returns an error.
+- Omitting `required_relations` (the default) skips these checks.
+
+---
+
+## 4. Documentation & Commenting Standards
+
+To ensure the generated API documentation (Swagger/OpenAPI) and TypeScript clients are well-documented, the following standards MUST be followed in all `.proto` files:
+
+### 4.1. General Principles
+- Use `//` for all descriptions.
+- Every RPC, Message, and Field must have a description.
+- Start with a clear summary line, followed by details on constraints or behavior.
+
+### 4.2. Field Metadata Labels
+Include explicit labels in field comments to denote behavior:
+- `// Required.` - For fields that must be provided.
+- `// Optional.` - For fields that can be omitted.
+- `// Read-only.` - For fields that are only populated by the server in responses.
+- `// Output only.` - Similar to read-only, specifically for create/update requests where the field is ignored.
+
+### 4.3. Permission Blocks
+Every RPC method comment must include a standardized permission block:
+```protobuf
+// [Description of the RPC]
+//
+// Required permissions:
+// - [scope_name] (or "Public" for open endpoints)
+```
+
+---
+
+## 5. Protocol Buffer Definition Samples
+
+### Permissions, Validations & Documentation
+Using the Qdrant pattern for permissions, `protovalidate` for field rules, and the documentation standards defined above.
+
+```protobuf
+syntax = "proto3";
+
+package authorizer.v1;
+
+import "google/api/annotations.proto";
+import "buf/validate/validate.proto";
+
+// Custom option for granular permission checks
+extend google.protobuf.MethodOptions {
+  string permissions = 50001;
+}
+
+service AuthorizerService {
+  // Signup registers a new user in the system.
+  //
+  // Required permissions:
+  // - Public
+  rpc Signup(SignUpRequest) returns (AuthResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/signup"
+      body: "*"
+    };
+    option (authorizer.v1.permissions) = "";
+  }
+
+  // GetProfile returns the profile of the currently authenticated user.
+  //
+  // Required permissions:
+  // - read:profile
+  rpc GetProfile(GetProfileRequest) returns (User) {
+    option (google.api.http) = {
+      get: "/api/v1/profile"
+    };
+    option (authorizer.v1.permissions) = "read:profile";
+  }
+}
+
+// SignUpRequest defines the parameters for user registration.
+// It supports both email-based and phone-based signup.
+message SignUpRequest {
+  // The unique email address for the user.
+  // Optional. If provided, must be a valid email format.
+  optional string email = 1 [(buf.validate.field).string.email = true];
+  
+  // The password for the account. Must be at least 8 characters.
+  // Required.
+  string password = 2 [(buf.validate.field).string.min_len = 8];
+  
+  // Confirmation of the password. Must match the 'password' field.
+  // Required.
+  string confirm_password = 3 [(buf.validate.field).string.min_len = 8];
+  
+  // The user's phone number in E.164 format.
+  // Optional. Example: +1234567890.
+  optional string phone_number = 4 [(buf.validate.field).string.pattern = "^\\+[1-9]\\d{1,14}$"];
+
+  // The first name of the user.
+  // Optional.
+  optional string given_name = 5;
+
+  // The last name of the user.
+  // Optional.
+  optional string family_name = 6;
+
+  // List of roles to be assigned to the user.
+  // Optional. Defaults to project's default roles if empty.
+  repeated string roles = 7;
+
+  // Arbitrary JSON data associated with the user.
+  // Optional.
+  map<string, string> app_data = 8;
+}
+```
+
+---
+
+## 4.1. Fine-Grained Authorization: Permission Check RPCs
+
+The `CheckPermissions` and `ListPermissions` RPCs provide OpenFGA-backed fine-grained authorization. They are optional — they fail gracefully when fine-grained authorization is not enabled (no `--fga-store`).
+
+### CheckPermissions
+
+Evaluates one or more permission checks in a single batch call. Answers the question: "Does the subject have <relation> on <object>?"
+
+**HTTP**: `POST /v1/check_permissions`
+
+**Request**:
+```json
+{
+  "checks": [
+    {
+      "relation": "can_edit",
+      "object": "document:12345",
+      "contextual_tuples": [
+        {
+          "user": "user:alice",
+          "relation": "viewer",
+          "object": "document:12345"
+        }
+      ]
+    }
+  ],
+  "user": "user:alice"
+}
+```
+
+**Response**:
+```json
+{
+  "results": [
+    {
+      "relation": "can_edit",
+      "object": "document:12345",
+      "allowed": false
+    }
+  ]
+}
+```
+
+**Subject Resolution**:
+- If `user` is omitted, the check uses the authenticated caller's subject from the context.
+- If `user` is provided, it is honored only if: (1) the caller is a super-admin, or (2) the `user` matches the caller's own subject (self-check).
+- Anything else is rejected with `unauthenticated` or `permission_denied`.
+
+**Fail-Closed**: If fine-grained authorization is not enabled, this RPC returns an error.
+
+### ListPermissions
+
+Enumerates what the subject can access, optionally filtered by relation and/or object type. Answers: "Which <object_type>s can I <relation>?"
+
+**HTTP**: `POST /v1/list_permissions`
+
+**Request**:
+```json
+{
+  "relation": "can_view",
+  "object_type": "document",
+  "user": "user:alice"
+}
+```
+
+**Response**:
+```json
+{
+  "objects": [
+    "document:12345",
+    "document:67890"
+  ],
+  "permissions": [
+    {
+      "object": "document:12345",
+      "relation": "can_view"
+    },
+    {
+      "object": "document:67890",
+      "relation": "can_view"
+    }
+  ],
+  "truncated": false
+}
+```
+
+**Parameters**:
+- `relation` (optional): Filter by relation (e.g., `can_view`, `can_edit`).
+- `object_type` (optional): Filter by object type (e.g., `document`, `folder`).
+- `user` (optional): Subject to enumerate permissions for (same trust rules as `CheckPermissions`).
+
+**Caps & Truncation**:
+- Results are capped at 1000 entries.
+- `truncated` is `true` if more permissions exist; the caller must refine filters or paginate.
+
+**Fail-Closed**: If fine-grained authorization is not enabled, this RPC returns an error.
+
+---
+
+## 6. Migration Strategy: Interface Pattern
+
+To avoid duplicating business logic between GraphQL and gRPC, all logic is moved to a unified `service.Provider` interface.
+
+### 1. Define the Interface
+```go
+// internal/service/provider.go
+package service
+
+type Provider interface {
+    // Authentication & Profile
+    Signup(ctx context.Context, params *SignUpRequest) (*AuthResponse, error)
+    Login(ctx context.Context, params *LoginRequest) (*AuthResponse, error)
+    MagicLinkLogin(ctx context.Context, params *MagicLinkLoginRequest) (*Response, error)
+    Logout(ctx context.Context) (*Response, error)
+    UpdateProfile(ctx context.Context, params *UpdateProfileRequest) (*Response, error)
+    VerifyEmail(ctx context.Context, params *VerifyEmailRequest) (*AuthResponse, error)
+    ResendVerifyEmail(ctx context.Context, params *ResendVerifyEmailRequest) (*Response, error)
+    ForgotPassword(ctx context.Context, params *ForgotPasswordRequest) (*ForgotPasswordResponse, error)
+    ResetPassword(ctx context.Context, params *ResetPasswordRequest) (*Response, error)
+    Revoke(ctx context.Context, params *OAuthRevokeRequest) (*Response, error)
+    VerifyOtp(ctx context.Context, params *VerifyOTPRequest) (*AuthResponse, error)
+    ResendOtp(ctx context.Context, params *ResendOTPRequest) (*Response, error)
+    DeactivateAccount(ctx context.Context) (*Response, error)
+    
+    // Metadata & Validation
+    GetMeta(ctx context.Context) (*Meta, error)
+    GetSession(ctx context.Context, params *SessionQueryRequest) (*AuthResponse, error)
+    GetProfile(ctx context.Context) (*User, error)
+    ValidateJwtToken(ctx context.Context, params *ValidateJWTTokenRequest) (*ValidateJWTTokenResponse, error)
+    ValidateSession(ctx context.Context, params *ValidateSessionRequest) (*ValidateSessionResponse, error)
+    
+    // Fine-grained Authorization (OpenFGA-backed)
+    CheckPermissions(ctx context.Context, params *CheckPermissionsRequest) (*CheckPermissionsResponse, error)
+    ListPermissions(ctx context.Context, params *ListPermissionsRequest) (*ListPermissionsResponse, error)
+}
+```
+
+### 2. Refactor Resolvers
+Existing GraphQL resolvers will be thin wrappers around this service, using encapsulated mapping methods:
+```go
+// internal/graph/schema.resolvers.go
+func (r *mutationResolver) Signup(ctx context.Context, params model.SignUpRequest) (*model.AuthResponse, error) {
+    // Convert GraphQL model to Service request
+    req := service.SignUpRequestFromGQL(params)
+    
+    // Call business logic
+    res, err := r.ServiceProvider.Signup(ctx, req)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Convert Service response back to GraphQL model
+    return res.AsGQL(), nil
+}
+```
+
+### 3. Implement gRPC Handler
+The gRPC server will similarly use the encapsulated mapping logic:
+```go
+// internal/grpc/handler.go
+func (s *Server) Signup(ctx context.Context, req *pb.SignUpRequest) (*pb.AuthResponse, error) {
+    // Convert gRPC proto to Service request
+    serviceReq := service.SignUpRequestFromPb(req)
+    
+    // Call business logic
+    res, err := s.ServiceProvider.Signup(ctx, serviceReq)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Convert Service response back to gRPC proto
+    return res.AsPb(), nil
+}
+```
+
+---
+
+## 7. Detailed Mapping Table
+
+> **Note:** The table in §2.1 is the authoritative, as-implemented mapping
+> (`snake_case` paths under `/v1`). The table below is the original design
+> sketch retained for historical context; where it differs (hyphenated paths,
+> `/api/v1` prefix, `Get*`/`DELETE`/`PUT` shapes), §2.1 wins.
+
+| gRPC Method | GraphQL Field | REST Gateway Path | Perms | Logic Method |
+| :--- | :--- | :--- | :--- | :--- |
+| `Signup` | `signup` | `POST /api/v1/signup` | - | `Signup` |
+| `Login` | `login` | `POST /api/v1/login` | - | `Login` |
+| `MagicLinkLogin` | `magic_link_login` | `POST /api/v1/magic-link` | - | `MagicLinkLogin` |
+| `Logout` | `logout` | `POST /api/v1/logout` | `auth` | `Logout` |
+| `UpdateProfile` | `update_profile` | `PUT /api/v1/profile` | `auth` | `UpdateProfile` |
+| `VerifyEmail` | `verify_email` | `POST /api/v1/verify-email` | - | `VerifyEmail` |
+| `ResendVerifyEmail` | `resend_verify_email` | `POST /api/v1/resend-verify` | - | `ResendVerifyEmail` |
+| `ForgotPassword` | `forgot_password` | `POST /api/v1/forgot-password` | - | `ForgotPassword` |
+| `ResetPassword` | `reset_password` | `POST /api/v1/reset-password` | - | `ResetPassword` |
+| `Revoke` | `revoke` | `POST /api/v1/revoke` | `auth` | `Revoke` |
+| `VerifyOtp` | `verify_otp` | `POST /api/v1/verify-otp` | - | `VerifyOtp` |
+| `ResendOtp` | `resend_otp` | `POST /api/v1/resend-otp` | - | `ResendOtp` |
+| `DeactivateAccount`| `deactivate_account` | `DELETE /api/v1/account` | `auth` | `DeactivateAccount`|
+| `GetMeta` | `meta` | `GET /api/v1/meta` | - | `GetMeta` |
+| `GetSession` | `session` | `POST /api/v1/session` | `auth` | `GetSession` |
+| `GetProfile` | `profile` | `GET /api/v1/profile` | `auth` | `GetProfile` |
+| `ValidateJwtToken` | `validate_jwt_token` | `POST /api/v1/validate-jwt` | - | `ValidateJwtToken` |
+| `ValidateSession` | `validate_session` | `POST /api/v1/validate-session` | - | `ValidateSession` |
+| `CheckPermissions` | `check_permissions` | `POST /api/v1/check-permissions` | `auth` | `CheckPermissions` |
+| `ListPermissions` | `list_permissions` | `POST /api/v1/list-permissions` | `auth` | `ListPermissions` |
+
+---
+
+## 8. Testing Strategy
+
+### 1. Service Logic Tests
+Unit tests for the `internal/service` implementation using mock storage and memory providers. These tests ensure business logic correctness regardless of the transport layer.
+
+### 2. Integration Tests (End-to-End)
+- **gRPC Integration**: Using `buf` generated client to call a test gRPC server.
+- **REST Gateway Integration**: Using standard HTTP clients to call the `/api/v1/...` endpoints.
+- **GraphQL Regression**: Ensuring existing GraphQL tests still pass after the refactor.
+
+### 3. Validation Tests
+Assert that `protovalidate` rules (e.g., email format) correctly reject invalid requests before they reach the business logic.
+
+---
+
+## 9. Development Workflow
+
+1.  **Modify Proto**: Edit files in `proto/authorizer/v1/`.
+2.  **Generate Code**:
+    ```bash
+    buf generate
+    ```
+3.  **Implement Service Logic**: Update `internal/service` if new fields or logic are added.
+4.  **Update Handlers**: Wire the new proto RPC to the service method.

--- a/specs/WORKLOAD_IDENTITY_PROGRAM.md
+++ b/specs/WORKLOAD_IDENTITY_PROGRAM.md
@@ -1,0 +1,702 @@
+# Workload Identity Program — Master Spec
+
+**Status:** Planning  
+**Date:** 2026-06-18  
+**Authors:** Principal Engineer, CTO, Security, Auth Expert
+
+---
+
+## 1. Executive Summary
+
+Authorizer currently supports only human-facing OAuth2 flows (`authorization_code`, `refresh_token`). It has no way for services, AI agents, or machines to authenticate. This program adds machine/workload identity as a first-class primitive in 6 ordered phases.
+
+**Dependency chain (must implement in order):**
+
+```
+Phase 1: Client Credentials + App Registration     ← FOUNDATION (unblocks everything)
+Phase 2: RFC 8693 Token Exchange                   ← depends on Phase 1
+Phase 3: Trusted External JWT Issuer Primitive     ← depends on Phase 1
+Phase 4: Kubernetes SA Token Auth                  ← depends on Phase 3
+Phase 5: SPIFFE JWT-SVID Auth (preview)            ← depends on Phase 3
+Phase 6: X.509-SVID mTLS Auth                      ← depends on Phase 5
+```
+
+---
+
+## 2. Standards Reference (Confirmed as of 2026-06-18)
+
+| Spec | Status | Role in this program |
+|---|---|---|
+| RFC 6749 §4.4 — Client Credentials Grant | Finalized | Phase 1 grant type |
+| RFC 7521 — Assertion Framework | Finalized | Basis for `client_assertion` |
+| RFC 7523 — JWT as `client_assertion` | Finalized | Phases 3–5 client-auth mechanism |
+| RFC 8693 — Token Exchange | Finalized | Phase 2 grant type |
+| RFC 8707 — Resource Indicators | Finalized | Audience binding on all issued tokens |
+| K8s SA OIDC/JWKS (upstream K8s docs) | Stable | Phase 4 key source |
+| K8s TokenReview API | Stable | Phase 4 optional hardening |
+| SPIFFE JWT-SVID (spiffe/spiffe standards) | Confirmed | Phase 5 identity format |
+| SPIFFE X.509-SVID (spiffe/spiffe standards) | Confirmed | Phase 6 identity format |
+| SPIFFE Trust Domain and Bundle | Confirmed | Phases 5–6 key management |
+| `draft-schwenkschuster-oauth-spiffe-client-auth-00` | **EXPIRED 2026-01-02, individual draft** | Phase 5 reference only — **ship as preview** |
+| RFC 9728 — Protected Resource Metadata | Finalized | **Does NOT apply here** (resource-server metadata only) |
+
+---
+
+## 3. New Database Schemas
+
+All new entities follow the existing schema pattern from `internal/storage/schemas/webhook.go`. Every field uses multi-DB struct tags: `json`, `bson`, `cql`, `dynamo`, `gorm`.
+
+### 3.1 App (`internal/storage/schemas/app.go`)
+
+```go
+package schemas
+
+import (
+    "encoding/json"
+    "strings"
+
+    "github.com/authorizerdev/authorizer/internal/graph/model"
+    "github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// App represents a registered machine/service application.
+// Note: any change here must be reflected in the cassandradb provider
+// (no model support for collection creation).
+type App struct {
+    Key         string  `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"` // ArangoDB key
+    ID          string  `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+    Name        string  `json:"name" bson:"name" cql:"name" dynamo:"name"`
+    Description *string `json:"description" bson:"description" cql:"description" dynamo:"description"`
+    ClientID    string  `gorm:"uniqueIndex;type:char(36)" json:"client_id" bson:"client_id" cql:"client_id" dynamo:"client_id" index:"client_id,hash"`
+    ClientSecret string  `json:"client_secret" bson:"client_secret" cql:"client_secret" dynamo:"client_secret"` // bcrypt-hashed; never returned in API responses
+    // AppType is one of: "machine" (M2M, client_credentials only),
+    // "web" (browser redirect flows), "native" (mobile/desktop).
+    AppType        string  `json:"app_type" bson:"app_type" cql:"app_type" dynamo:"app_type"`
+    // AllowedScopes is a comma-separated list of scopes this app may request.
+    AllowedScopes  string  `json:"allowed_scopes" bson:"allowed_scopes" cql:"allowed_scopes" dynamo:"allowed_scopes"`
+    IsActive       bool    `json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active"`
+    CreatedAt      int64   `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+    UpdatedAt      int64   `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+// AsAPIApp converts App to GraphQL model. Never exposes ClientSecret.
+func (a *App) AsAPIApp() *model.App {
+    id := a.ID
+    if strings.Contains(id, Collections.App+"/") {
+        id = strings.TrimPrefix(id, Collections.App+"/")
+    }
+    return &model.App{
+        ID:            id,
+        Name:          a.Name,
+        Description:   a.Description,
+        ClientID:      a.ClientID,
+        AppType:       a.AppType,
+        AllowedScopes: strings.Split(a.AllowedScopes, ","),
+        IsActive:      a.IsActive,
+        CreatedAt:     refs.NewInt64Ref(a.CreatedAt),
+        UpdatedAt:     refs.NewInt64Ref(a.UpdatedAt),
+    }
+}
+```
+
+**ClientSecret handling:** store as bcrypt hash (cost 12). The raw secret is returned **once** at creation and **never again**. Rotation creates a new secret.
+
+### 3.2 TrustedIssuer (`internal/storage/schemas/trusted_issuer.go`)
+
+```go
+package schemas
+
+import (
+    "strings"
+
+    "github.com/authorizerdev/authorizer/internal/graph/model"
+    "github.com/authorizerdev/authorizer/internal/refs"
+)
+
+// TrustedIssuer is an external JWT issuer whose tokens the system will accept
+// as client credentials (via client_assertion / RFC 7523).
+// Covers: Kubernetes SA tokens, SPIFFE JWT-SVIDs, cloud OIDC tokens.
+//
+// Note: any change here must be reflected in cassandradb provider.
+type TrustedIssuer struct {
+    Key  string `json:"_key,omitempty" bson:"_key,omitempty" cql:"_key,omitempty" dynamo:"key,omitempty"`
+    ID   string `gorm:"primaryKey;type:char(36)" json:"_id" bson:"_id" cql:"id" dynamo:"id,hash"`
+    // AppID links this issuer to an App. Tokens from this issuer authenticate AS that App.
+    AppID        string  `json:"app_id" bson:"app_id" cql:"app_id" dynamo:"app_id" index:"app_id,hash"`
+    Name         string  `json:"name" bson:"name" cql:"name" dynamo:"name"`
+    // IssuerURL is the `iss` claim value in JWTs from this issuer,
+    // OR the SPIFFE trust domain (e.g. "spiffe://example.org") for SPIFFE issuers.
+    IssuerURL    string  `gorm:"uniqueIndex" json:"issuer_url" bson:"issuer_url" cql:"issuer_url" dynamo:"issuer_url" index:"issuer_url,hash"`
+    // KeySourceType determines how JWKS are fetched:
+    //   "oidc_discovery"       — fetch from <IssuerURL>/.well-known/openid-configuration
+    //   "static_jwks_url"      — fetch directly from JWKSUrl (required for private clusters)
+    //   "spiffe_bundle_endpoint" — fetch from SPIFFE bundle endpoint (Phase 5)
+    KeySourceType string  `json:"key_source_type" bson:"key_source_type" cql:"key_source_type" dynamo:"key_source_type"`
+    // JWKSUrl is required when KeySourceType is "static_jwks_url".
+    JWKSUrl      *string `json:"jwks_url" bson:"jwks_url" cql:"jwks_url" dynamo:"jwks_url"`
+    // ExpectedAud is the audience claim value the token MUST contain.
+    // For K8s SA tokens this MUST be Authorizer's issuer URL (configured via --issuer-url flag).
+    ExpectedAud  string  `json:"expected_aud" bson:"expected_aud" cql:"expected_aud" dynamo:"expected_aud"`
+    // SubjectClaim is the JWT claim used to identify the workload (usually "sub").
+    SubjectClaim string  `json:"subject_claim" bson:"subject_claim" cql:"subject_claim" dynamo:"subject_claim"`
+    // IssuerType is one of: "kubernetes_sa" | "spiffe_jwt" | "oidc" | "cloud_oidc"
+    IssuerType   string  `json:"issuer_type" bson:"issuer_type" cql:"issuer_type" dynamo:"issuer_type"`
+    IsActive     bool    `json:"is_active" bson:"is_active" cql:"is_active" dynamo:"is_active"`
+    // SpiffeRefreshHintSeconds controls JWKS refresh cadence for SPIFFE bundle endpoints.
+    // Default 300 (5 min) if 0. Ignored for non-SPIFFE key sources.
+    SpiffeRefreshHintSeconds int64  `json:"spiffe_refresh_hint_seconds" bson:"spiffe_refresh_hint_seconds" cql:"spiffe_refresh_hint_seconds" dynamo:"spiffe_refresh_hint_seconds"`
+    CreatedAt    int64   `json:"created_at" bson:"created_at" cql:"created_at" dynamo:"created_at"`
+    UpdatedAt    int64   `json:"updated_at" bson:"updated_at" cql:"updated_at" dynamo:"updated_at"`
+}
+
+func (t *TrustedIssuer) AsAPITrustedIssuer() *model.TrustedIssuer {
+    id := t.ID
+    if strings.Contains(id, Collections.TrustedIssuer+"/") {
+        id = strings.TrimPrefix(id, Collections.TrustedIssuer+"/")
+    }
+    return &model.TrustedIssuer{
+        ID:                       id,
+        AppID:                    t.AppID,
+        Name:                     t.Name,
+        IssuerURL:                t.IssuerURL,
+        KeySourceType:            t.KeySourceType,
+        JWKSUrl:                  t.JWKSUrl,
+        ExpectedAud:              t.ExpectedAud,
+        SubjectClaim:             t.SubjectClaim,
+        IssuerType:               t.IssuerType,
+        IsActive:                 t.IsActive,
+        SpiffeRefreshHintSeconds: refs.NewInt64Ref(t.SpiffeRefreshHintSeconds),
+        CreatedAt:                refs.NewInt64Ref(t.CreatedAt),
+        UpdatedAt:                refs.NewInt64Ref(t.UpdatedAt),
+    }
+}
+```
+
+### 3.3 Collections Registry addition (`internal/storage/schemas/model.go`)
+
+Add to the existing `Collections` struct:
+```go
+App           = "authorizer_apps"
+TrustedIssuer = "authorizer_trusted_issuers"
+```
+
+---
+
+## 4. Storage Interface Additions (`internal/storage/provider.go`)
+
+Add these method signatures to the `Provider` interface. Each DB provider must implement all of them.
+
+```go
+// ===== App methods =====
+
+// AddApp creates a new application record.
+AddApp(ctx context.Context, app *schemas.App) (*schemas.App, error)
+
+// UpdateApp updates an existing application record.
+UpdateApp(ctx context.Context, app *schemas.App) (*schemas.App, error)
+
+// DeleteApp removes an application record.
+DeleteApp(ctx context.Context, app *schemas.App) error
+
+// GetAppByID fetches an app by its primary key.
+GetAppByID(ctx context.Context, id string) (*schemas.App, error)
+
+// GetAppByClientID fetches an app by its OAuth2 client_id.
+GetAppByClientID(ctx context.Context, clientID string) (*schemas.App, error)
+
+// ListApps returns a paginated list of all apps.
+ListApps(ctx context.Context, pagination *model.Pagination) ([]*schemas.App, *model.Pagination, error)
+
+// ===== TrustedIssuer methods =====
+
+// AddTrustedIssuer creates a new trusted issuer record.
+AddTrustedIssuer(ctx context.Context, issuer *schemas.TrustedIssuer) (*schemas.TrustedIssuer, error)
+
+// UpdateTrustedIssuer updates an existing trusted issuer.
+UpdateTrustedIssuer(ctx context.Context, issuer *schemas.TrustedIssuer) (*schemas.TrustedIssuer, error)
+
+// DeleteTrustedIssuer removes a trusted issuer.
+DeleteTrustedIssuer(ctx context.Context, issuer *schemas.TrustedIssuer) error
+
+// GetTrustedIssuerByID fetches a trusted issuer by primary key.
+GetTrustedIssuerByID(ctx context.Context, id string) (*schemas.TrustedIssuer, error)
+
+// GetTrustedIssuerByIssuerURL fetches a trusted issuer by its issuer URL / trust domain.
+GetTrustedIssuerByIssuerURL(ctx context.Context, issuerURL string) (*schemas.TrustedIssuer, error)
+
+// ListTrustedIssuers returns all trusted issuers, optionally filtered by app_id.
+ListTrustedIssuers(ctx context.Context, appID string, pagination *model.Pagination) ([]*schemas.TrustedIssuer, *model.Pagination, error)
+```
+
+---
+
+## 5. Database Provider Implementation Checklist
+
+Every new entity must be implemented in **all 6 providers**. Follow the pattern of the corresponding `webhook.go` file in each provider directory.
+
+| Provider | Directory | Pattern reference |
+|---|---|---|
+| SQL (postgres/sqlite/mysql/etc.) | `internal/storage/db/sql/` | `sql/webhook.go` |
+| MongoDB | `internal/storage/db/mongodb/` | `mongodb/webhook.go` |
+| ArangoDB | `internal/storage/db/arangodb/` | `arangodb/webhook.go` |
+| CassandraDB/Scylla | `internal/storage/db/cassandradb/` | `cassandradb/webhook.go` |
+| DynamoDB | `internal/storage/db/dynamodb/` | `dynamodb/webhook.go` |
+| Couchbase | `internal/storage/db/couchbase/` | `couchbase/webhook.go` |
+
+**SQL auto-migration:** Add `&schemas.App{}` and `&schemas.TrustedIssuer{}` to the `AutoMigrate` call in `internal/storage/db/sql/provider.go`.
+
+**CassandraDB note:** CassandraDB does not use GORM AutoMigrate. Table DDL must be added manually in `cassandradb/provider.go`. See existing collection-creation code there for the pattern.
+
+**DynamoDB note:** DynamoDB uses on-demand table creation. Add table-creation calls in `dynamodb/provider.go` following the existing pattern.
+
+---
+
+## 6. GraphQL Schema Additions (`internal/graph/schema.graphqls`)
+
+Add these types, inputs, queries, and mutations. After editing, run `make generate-graphql`.
+
+### New Types
+
+```graphql
+type App {
+  id: ID!
+  name: String!
+  description: String
+  client_id: String!
+  # client_secret is NEVER returned after initial creation
+  # It is returned once in CreateAppResponse only
+  app_type: String!
+  allowed_scopes: [String!]!
+  is_active: Boolean!
+  created_at: Int64
+  updated_at: Int64
+}
+
+type CreateAppResponse {
+  app: App!
+  # client_secret returned ONCE at creation; store securely
+  client_secret: String!
+}
+
+type Apps {
+  pagination: Pagination!
+  apps: [App!]!
+}
+
+type TrustedIssuer {
+  id: ID!
+  app_id: String!
+  name: String!
+  issuer_url: String!
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  subject_claim: String!
+  issuer_type: String!
+  is_active: Boolean!
+  spiffe_refresh_hint_seconds: Int64
+  created_at: Int64
+  updated_at: Int64
+}
+
+type TrustedIssuers {
+  pagination: Pagination!
+  trusted_issuers: [TrustedIssuer!]!
+}
+```
+
+### New Input Types
+
+```graphql
+input CreateAppRequest {
+  name: String!
+  description: String
+  # app_type: "machine" | "web" | "native"
+  app_type: String!
+  allowed_scopes: [String!]!
+}
+
+input UpdateAppRequest {
+  id: ID!
+  name: String
+  description: String
+  allowed_scopes: [String!]
+  is_active: Boolean
+}
+
+input AppRequest {
+  id: ID!
+}
+
+input ListAppsRequest {
+  pagination: PaginatedRequest
+}
+
+input AddTrustedIssuerRequest {
+  app_id: String!
+  name: String!
+  issuer_url: String!
+  # key_source_type: "oidc_discovery" | "static_jwks_url" | "spiffe_bundle_endpoint"
+  key_source_type: String!
+  jwks_url: String
+  expected_aud: String!
+  # subject_claim defaults to "sub" if omitted
+  subject_claim: String
+  # issuer_type: "kubernetes_sa" | "spiffe_jwt" | "oidc" | "cloud_oidc"
+  issuer_type: String!
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input UpdateTrustedIssuerRequest {
+  id: ID!
+  name: String
+  jwks_url: String
+  expected_aud: String
+  is_active: Boolean
+  spiffe_refresh_hint_seconds: Int64
+}
+
+input TrustedIssuerRequest {
+  id: ID!
+}
+
+input ListTrustedIssuersRequest {
+  app_id: String
+  pagination: PaginatedRequest
+}
+
+# Phase 2 — Token Exchange
+input TokenExchangeRequest {
+  subject_token: String!
+  subject_token_type: String!
+  requested_token_type: String
+  resource: String
+  audience: String
+  scope: String
+  actor_token: String
+  actor_token_type: String
+}
+```
+
+### New Admin Mutations (all `_` prefixed — admin only)
+
+```graphql
+# Phase 1
+_create_app(params: CreateAppRequest!): CreateAppResponse!
+_update_app(params: UpdateAppRequest!): App!
+_delete_app(params: AppRequest!): Response!
+_rotate_app_secret(params: AppRequest!): CreateAppResponse!
+
+# Phases 3–5
+_add_trusted_issuer(params: AddTrustedIssuerRequest!): TrustedIssuer!
+_update_trusted_issuer(params: UpdateTrustedIssuerRequest!): TrustedIssuer!
+_delete_trusted_issuer(params: TrustedIssuerRequest!): Response!
+```
+
+### New Admin Queries (all `_` prefixed)
+
+```graphql
+_app(params: AppRequest!): App!
+_apps(params: ListAppsRequest): Apps!
+_trusted_issuer(params: TrustedIssuerRequest!): TrustedIssuer!
+_trusted_issuers(params: ListTrustedIssuersRequest): TrustedIssuers!
+```
+
+---
+
+## 7. gRPC Proto Additions
+
+### `proto/authorizer/v1/admin.proto` additions
+
+```protobuf
+// ===== App management =====
+rpc CreateApp(CreateAppRequest) returns (CreateAppResponse);
+rpc UpdateApp(UpdateAppRequest) returns (App);
+rpc DeleteApp(AppRequest) returns (Response);
+rpc RotateAppSecret(AppRequest) returns (CreateAppResponse);
+rpc GetApp(AppRequest) returns (App);
+rpc ListApps(ListAppsRequest) returns (Apps);
+
+// ===== TrustedIssuer management =====
+rpc AddTrustedIssuer(AddTrustedIssuerRequest) returns (TrustedIssuer);
+rpc UpdateTrustedIssuer(UpdateTrustedIssuerRequest) returns (TrustedIssuer);
+rpc DeleteTrustedIssuer(TrustedIssuerRequest) returns (Response);
+rpc GetTrustedIssuer(TrustedIssuerRequest) returns (TrustedIssuer);
+rpc ListTrustedIssuers(ListTrustedIssuersRequest) returns (TrustedIssuers);
+```
+
+After editing proto files, run `make proto-gen` and commit the `gen/` changes.
+
+---
+
+## 8. Token Endpoint Changes (`internal/http_handlers/token.go`)
+
+### Phase 1 — client_credentials
+
+Extend `RequestBody`:
+```go
+type RequestBody struct {
+    // existing fields ...
+    CodeVerifier string `form:"code_verifier" json:"code_verifier"`
+    Code         string `form:"code" json:"code"`
+    ClientID     string `form:"client_id" json:"client_id"`
+    ClientSecret string `form:"client_secret" json:"client_secret"`
+    GrantType    string `form:"grant_type" json:"grant_type"`
+    RefreshToken string `form:"refresh_token" json:"refresh_token"`
+    RedirectURI  string `form:"redirect_uri" json:"redirect_uri"`
+    // Phase 1 additions:
+    Scope        string `form:"scope" json:"scope"`
+    // Phase 2 additions:
+    SubjectToken     string `form:"subject_token" json:"subject_token"`
+    SubjectTokenType string `form:"subject_token_type" json:"subject_token_type"`
+    ActorToken       string `form:"actor_token" json:"actor_token"`
+    ActorTokenType   string `form:"actor_token_type" json:"actor_token_type"`
+    RequestedTokenType string `form:"requested_token_type" json:"requested_token_type"`
+    Resource         string `form:"resource" json:"resource"`
+    Audience         string `form:"audience" json:"audience"`
+    // Phases 3–5 additions:
+    ClientAssertion     string `form:"client_assertion" json:"client_assertion"`
+    ClientAssertionType string `form:"client_assertion_type" json:"client_assertion_type"`
+}
+```
+
+Extend the `grantType` switch to add:
+```go
+const (
+    GrantTypeAuthorizationCode = "authorization_code"
+    GrantTypeRefreshToken      = "refresh_token"
+    GrantTypeClientCredentials = "client_credentials"                                        // Phase 1
+    GrantTypeTokenExchange     = "urn:ietf:params:oauth:grant-type:token-exchange"           // Phase 2
+)
+
+const (
+    ClientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" // Phases 3–4
+    ClientAssertionTypeJWTSPIFFE = "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe" // Phase 5 (preview)
+)
+```
+
+---
+
+## 9. New Service Files
+
+| File | Phase | Purpose |
+|---|---|---|
+| `internal/service/app.go` | 1 | App CRUD + secret management |
+| `internal/service/token_exchange.go` | 2 | RFC 8693 token exchange logic |
+| `internal/service/jwks_cache.go` | 3 | JWKS fetching, caching, refresh |
+| `internal/service/workload_auth.go` | 3 | JWT client-assertion validation |
+| `internal/service/kubernetes_sa_auth.go` | 4 | K8s SA token validation |
+| `internal/service/spiffe_auth.go` | 5 | SPIFFE JWT-SVID validation |
+| `internal/service/mtls_auth.go` | 6 | X.509-SVID mTLS extraction |
+
+---
+
+## 10. New Token Claims
+
+### Phase 1 — client_credentials access token
+
+```go
+// AuthTokenConfig additions for machine tokens
+type AuthTokenConfig struct {
+    // existing fields ...
+    // Phase 1: machine identity
+    AppID      string   // set for client_credentials tokens
+    AppScopes  []string // granted scopes for this token
+    // Phase 2: delegation
+    ActorSub   string   // subject of the actor token (act.sub claim)
+    ActorISS   string   // issuer of the actor token (act.iss claim)
+}
+```
+
+JWT `act` claim structure (RFC 8693 §4.1):
+```json
+{
+  "sub": "service-account-a",
+  "act": {
+    "sub": "agent-xyz",
+    "iss": "https://authorizer.example.com"
+  }
+}
+```
+
+The `act` claim must be added to the `reservedClaims` map in `internal/token/auth_token.go`.
+
+---
+
+## 11. JWKS Cache Design (`internal/service/jwks_cache.go`)
+
+```go
+// JWKSCache caches JWKS key sets per issuer URL.
+// Thread-safe. Refreshes on TTL or on validation failure (key rotation).
+type JWKSCache interface {
+    // GetKeySet returns the current KeySet for the given issuer.
+    // Fetches from remote if not cached or TTL expired.
+    GetKeySet(ctx context.Context, issuer *schemas.TrustedIssuer) (jwk.Set, error)
+    // InvalidateAndRefresh forces an immediate refresh (call on validation failure).
+    InvalidateAndRefresh(ctx context.Context, issuerURL string) (jwk.Set, error)
+}
+```
+
+**Library:** `github.com/lestrrat-go/jwx/v2` — provides `jwk.AutoRefresh` with configurable TTL. Already used widely in the Go ecosystem; zero-SPIFFE-dependency for the base JWKS cache. For SPIFFE bundle endpoints, use `github.com/spiffe/go-spiffe/v2` bundle packages.
+
+**Refresh cadence:**
+- OIDC discovery / static JWKS: refresh every 60 minutes or on key-not-found
+- SPIFFE bundle endpoint: refresh every `spiffe_refresh_hint_seconds` (default 300s). This is a **hard runtime requirement** — failure to refresh will reject valid SVIDs after trust-bundle rotation.
+
+---
+
+## 12. Security Invariants (ALL phases must uphold)
+
+These are non-negotiable. Every implementation must satisfy all of them.
+
+### S1 — Audience binding (mandatory)
+Every external JWT presented as a `client_assertion` MUST have an `aud` claim that exactly matches Authorizer's configured issuer URL (`--issuer-url`). Reject with `invalid_client` if absent or mismatched. Without this, any SA token minted for another service (e.g. Vault) can be replayed against Authorizer.
+
+### S2 — Algorithm allow-list (mandatory)
+Only accept: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`.
+Reject `HS*` (symmetric — issuer and verifier share the secret, which breaks third-party issuer model), `none`, and any unrecognised algorithm. Return `invalid_client`.
+
+### S3 — `exp` required (mandatory)
+Every presented JWT MUST have an `exp` claim. Reject if absent. Reject if expired.
+
+### S4 — SPIFFE alg constraint (mandatory for Phase 5)
+SPIFFE JWT-SVIDs additionally restrict to RFC 7518 §3.3–3.5 asymmetric algorithms only. `alg:none` is explicitly forbidden by the SPIFFE JWT-SVID standard.
+
+### S5 — X.509-SVID leaf constraints (mandatory for Phase 6)
+When validating an X.509-SVID:
+- `cA` MUST be `false`
+- `digitalSignature` key usage MUST be set
+- `keyCertSign` and `cRLSign` MUST NOT be set
+- SPIFFE ID MUST be in URI SAN (exactly one SPIFFE URI SAN per leaf cert)
+- SPIFFE ID path MUST be non-empty (reject root-path SVIDs)
+
+### S6 — No client_secret in response after creation (mandatory)
+`client_secret` MUST NOT appear in any API response except the initial `CreateApp` / `RotateAppSecret` response. Store only the bcrypt hash (cost 12).
+
+### S7 — Offline-validation staleness gap (must document)
+OIDC/JWKS offline validation does NOT verify the bound K8s object (Pod/SA) still exists. Document this explicitly in: the API response for TrustedIssuer creation, the operator guide, and any error messages. For Phase 4, offer an optional `enable_token_review` flag on the TrustedIssuer record.
+
+### S8 — RFC 8707 audience on issued tokens (mandatory for Phase 2+)
+Every Authorizer access token issued as a result of a workload-identity flow MUST carry the `resource` / `aud` claim. Confused-deputy mitigation is doubly critical for machine tokens that call many services.
+
+### S9 — Scope attenuation (mandatory for Phase 2)
+In token exchange, the issued token's scopes MUST be a subset of the subject token's scopes. Never grant more than what the subject token authorised.
+
+### S10 — Static JWKS URL option (mandatory for Phase 3+)
+Never require OIDC discovery as the only key-source option. Private K8s clusters cannot expose `/.well-known/openid-configuration` publicly. `key_source_type: "static_jwks_url"` with a `jwks_url` field is required from day one.
+
+---
+
+## 13. Token Endpoint Response Formats
+
+### Phase 1 — `client_credentials` success (RFC 6749 §5.1)
+```json
+{
+  "access_token": "eyJ...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read write"
+}
+```
+No `refresh_token` for machine tokens (machines re-authenticate on expiry).
+
+### Phase 2 — token exchange success (RFC 8693 §2.2.1)
+```json
+{
+  "access_token": "eyJ...",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read"
+}
+```
+
+### Phase 1–5 — error responses (RFC 6749 §5.2)
+```json
+{
+  "error": "invalid_client",
+  "error_description": "client_assertion signature verification failed"
+}
+```
+
+Common error codes for this program:
+- `invalid_client` — bad client_id/secret, bad assertion, expired token, audience mismatch
+- `invalid_grant` — token exchange subject_token invalid or expired
+- `unsupported_grant_type` — grant_type not supported
+- `invalid_scope` — requested scope exceeds allowed_scopes for app
+- `invalid_request` — missing required parameter
+
+---
+
+## 14. Audit Log Events
+
+Add these to `internal/constants/` audit event constants:
+
+```go
+const (
+    // Phase 1
+    AuditEventAppCreated       = "app.created"
+    AuditEventAppUpdated       = "app.updated"
+    AuditEventAppDeleted       = "app.deleted"
+    AuditEventAppSecretRotated = "app.secret_rotated"
+    AuditEventClientCredentials = "token.client_credentials"
+
+    // Phase 2
+    AuditEventTokenExchange    = "token.exchange"
+
+    // Phases 3–5
+    AuditEventWorkloadAuth     = "token.workload_auth"
+    AuditEventTrustedIssuerAdded   = "trusted_issuer.added"
+    AuditEventTrustedIssuerUpdated = "trusted_issuer.updated"
+    AuditEventTrustedIssuerDeleted = "trusted_issuer.deleted"
+)
+```
+
+---
+
+## 15. Go Dependencies (new)
+
+| Package | Version | Purpose | Phase |
+|---|---|---|---|
+| `github.com/lestrrat-go/jwx/v2` | latest stable | JWKS fetch + JWT validation for external tokens | 3 |
+| `github.com/spiffe/go-spiffe/v2` | latest stable | SPIFFE bundle endpoint fetching + JWT-SVID validation | 5 |
+| `golang.org/x/crypto/bcrypt` | stdlib | Client secret hashing | 1 |
+
+Note: `golang.org/x/crypto` is already a transitive dependency — no new import needed. Check `go.mod` before adding anything.
+
+---
+
+## 16. Implementation Agent Assignments
+
+| Phase | Plan file | Recommended agent |
+|---|---|---|
+| 1 — Client Credentials + App Registration | `docs/superpowers/plans/2026-06-18-phase1-client-credentials-app-registration.md` | `principal-engineer` |
+| 2 — RFC 8693 Token Exchange | `docs/superpowers/plans/2026-06-18-phase2-token-exchange.md` | `delegation-engineer` |
+| 3 — Trusted JWT Issuer Primitive | `docs/superpowers/plans/2026-06-18-phase3-trusted-jwt-issuer.md` | `principal-engineer` |
+| 4 — K8s SA Token Auth | `docs/superpowers/plans/2026-06-18-phase4-kubernetes-sa-auth.md` | `principal-engineer` |
+| 5 — SPIFFE JWT-SVID Auth (preview) | `docs/superpowers/plans/2026-06-18-phase5-spiffe-jwt-svid.md` | `security-engineer` |
+| 6 — X.509-SVID mTLS | `docs/superpowers/plans/2026-06-18-phase6-x509-mtls.md` | `security-engineer` |
+
+Each plan file is self-contained and references this master spec. An agent implementing any phase MUST read this master spec first.
+
+---
+
+## 17. Branch Naming and PR Convention
+
+- Phase 1: `feat/workload-identity-phase1-client-credentials`
+- Phase 2: `feat/workload-identity-phase2-token-exchange`
+- Phase 3: `feat/workload-identity-phase3-trusted-issuer`
+- Phase 4: `feat/workload-identity-phase4-k8s-sa-auth`
+- Phase 5: `feat/workload-identity-phase5-spiffe-jwt-svid`
+- Phase 6: `feat/workload-identity-phase6-x509-mtls`
+
+Each PR must pass: `make lint`, `make test-sqlite`, and CI green before merge. Phase 5 PR additionally requires `security-engineer` review.
+
+---
+
+## 18. What Does NOT Change
+
+- Human auth flows (`authorization_code`, `refresh_token`, social logins, MFA, magic links) — untouched
+- Existing `User` model — no changes
+- OpenFGA integration — machine identities become new principals in FGA tuples; no schema change to FGA
+- The existing single `ClientID`/`ClientSecret` global config — retained for backward compatibility; new per-App registration is additive

--- a/specs/machine-agent-identity/IMPLEMENTATION_PLAN.md
+++ b/specs/machine-agent-identity/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,140 @@
+# Machine & Agent Identity — Implementation Plan
+
+Branch: `feat/machine-agent-identity` (off `origin/main`). Single large branch, manually tested per phase before any merge.
+
+Design source of truth: the Rev. 5.1 design doc (client registry, unified `TrustedIssuer`, organizations, SSO/SCIM, delegation). Section references below (§4.1 etc.) point at that doc.
+
+This plan is written so an implementing subagent can follow it without re-deriving decisions. Each feature lists **DB · API · UI · Tests** and the **build gate** that must pass before the next unit starts.
+
+---
+
+## Ground rules (every subagent obeys)
+
+1. **Never commit to `main`.** Work only on `feat/machine-agent-identity`.
+2. **Schema change ⇒ all 6 storage providers.** SQL (GORM), MongoDB, ArangoDB, Cassandra/Scylla, DynamoDB, Couchbase. Wire the table into `internal/storage/schemas/model.go` `Collections`, then each provider's migration path.
+3. **`make generate-graphql`** after editing `internal/graph/schema.graphqls`; commit `gen/`-equivalent output.
+4. **`make proto-gen`** after editing `proto/`; commit `gen/`.
+5. **Transports stay thin.** Shared logic in `internal/service/` behind a `Provider` interface (`Dependencies` struct + `New()`), not in handlers.
+6. **Admin GraphQL ops are `_`-prefixed.**
+7. **Secrets carry `json:"-"`** and never appear in a read projection. Provider round-trip test must assert the hash persists AND never serializes out.
+8. **Build gate = `go build ./... && make lint-go && go vet ./...`** compiles clean; **test gate = `TEST_DBS=sqlite go test -p 1 ./internal/...`** green. Storage tests honor `TEST_DBS`.
+9. **gin-context error pattern** (PR #638/#639): resolvers do `gc, err := utils.GinContextFromContext(ctx)`, return the error, record the security metric; fire-and-forget goroutines use `context.WithoutCancel`.
+10. **Audit events** use the dotted `<actor>.<action>` scheme in `internal/constants/audit_event.go`, success AND failure.
+
+---
+
+## Phase A — Client registry foundation (the load-bearing phase)
+
+Goal: replace the global `Config.ClientID`/`ClientSecret` and the (unreleased) `ServiceAccount` entity with one authoritative `authorizer_clients` table, behind a shared client-authentication resolver, **without breaking existing single-client deployments**.
+
+### A0 — Backward-compat invariants (write these as tests FIRST, then keep them green)
+
+- **BC1**: the seeded reserved client's OAuth `client_id` == the literal `Config.ClientID`. `aud` on every token, JWKS `kid`, introspection `client_id`, and `client_check` all continue to key on that exact string. A surrogate UUID may only be an internal PK.
+- **BC2**: the session-cookie AES key stays bound to `Config.ClientSecret` (or a dedicated key), NOT the per-client bcrypt hash. `crypto.EncryptAES(Config.ClientSecret, …)` in `auth_token.go` is untouched; rotating a client's stored secret must not change cookie crypto.
+- **BC3**: multi-client `aud` minting/validation is explicitly in this phase — `jwt.go` single-`aud` validation and introspection audience check become registry-aware, but the existing client's `aud` stays `Config.ClientID`.
+
+Regression tests (add before code): existing token still validates; existing session cookie still decrypts; discovery/JWKS shapes unchanged; introspection response fields unchanged.
+
+### A1 — Schema: `authorizer_clients`
+
+- **DB**: struct `internal/storage/schemas/client.go` (see design §4.7 table). Columns: `id` (PK surrogate), `client_id` (unique), `kind` (immutable: `interactive`|`service_account`), `client_secret_hash` (`json:"-"`, nullable), `redirect_uris`, `grant_types`, `allowed_scopes`, `max_scopes`, `token_endpoint_auth_method`, `org_id` (nullable FK), timestamps. Add to `Collections`. Migrate in all 6 providers. Index `client_id` (unique) and `org_id`.
+- **Tests**: shared `internal/storage/provider_test.go` round-trip on the struct — write→read→assert every field incl. `client_secret_hash` persists and never JSON-serializes; unique `client_id`; `org_id` filter. Runs on all `TEST_DBS`.
+- **Build gate**, then **test gate** on sqlite.
+
+### A2 — Seed + config bridge
+
+- **DB**: idempotent upsert keyed on `client_id == Config.ClientID` at boot, after `storage.New` in `cmd/root.go` (before Token/HTTP). Seed as `kind=interactive`, confidential, PKCE enforced, `client_secret_hash = bcrypt(Config.ClientSecret)`. Idempotent (skip-if-present); read-replica/no-write-path instance skips rather than fatals.
+- **Tests**: boot twice → one row; concurrent seed → no duplicate (per-provider upsert semantics).
+
+### A3 — Client-authentication resolver
+
+- **API/service**: new `internal/service/clientauth` (or fold into an existing service) `Provider` with `ResolveAndAuthenticate(ctx, req) (*Client, error)`. Methods: `client_secret_basic`, `client_secret_post`, `none` (public+PKCE). RFC 6749 §2.3: reject >1 auth method. Constant-time / dummy-hash on miss for every kind (extend the existing service-account timing guard to the interactive path). Cached read-through lookup in the shared `memory_store` (Redis), cross-instance invalidation on write; `Config.ClientID` remains bootstrap seed + fallback so an empty/unreachable table can't lock out login.
+- Repoint the 6+ static config-comparison sites to consume the resolver: `token.go`, `introspect.go` (caller-auth per RFC 7662), `revoke_refresh_token.go` (token-ownership per RFC 7009), `client_check.go`, `app.go` (serve reserved client's id), `authorize.go`.
+- **Tests**: each method authenticates the seeded client; wrong secret rejected constant-time; dual-method rejected; unknown client → dummy-hash timing; introspection/revoke ownership checks.
+
+### A4 — GraphQL/gRPC admin surface `_client_*`
+
+- **API**: `internal/graph/schema.graphqls` — `type Client`, `_create_client`/`_update_client`/`_delete_client`/`_client`/`_clients` (`_`-prefixed). Ship these names directly; never ship `_service_account_*`. `kind` immutable in `_update`. Kind-aware projection (never returns `client_secret_hash`). One-time secret reveal on create for `service_account`/confidential. Admin-suppliable `client_id` (default system-generated). `make generate-graphql`. Mirror on gRPC admin (`internal/grpcsrv/handlers/`).
+- **UI**: `web/dashboard` — a "Clients" admin page (list/create/edit/delete, one-time secret reveal). Keep `meta.client_id` returning the reserved client. `web/app` `/app` bootstrap stays pinned to the reserved client (defer 2nd-interactive-client delivery).
+- **Tests**: integration test — create client via GraphQL, secret revealed once, never leaks on get/list; `kind` immutable; admin-supplied id honored.
+
+### A5 — service_account grant + discovery metadata + refresh rotation
+
+- **API**: `client_credentials` grant on `/oauth/token` uses the resolver; `service_account` client, `max_scopes` ceiling, scope-subset enforcement, bcrypt-12 secret, audit `token.client_credentials`/`_failed`. `.well-known/openid-configuration` + `oauth-authorization-server` advertise `grant_types_supported` incl. `client_credentials` and (reserved for B/D) the new methods; refresh-token rotation for public interactive clients (RFC 9700 §4.14.2); exact redirect-URI matching per client (§4.1/G10).
+- **Tests**: e2e — admin creates `service_account`, authenticates at `/oauth/token`, token validates, scopes enforced; discovery advertises `client_credentials`; refresh rotation detects replay.
+
+**Phase A done when**: all gates green on sqlite + the backward-compat regression suite passes + a manual smoke of the existing login flow works unchanged.
+
+---
+
+## Phase B — Secretless client auth (`TrustedIssuer` + client_assertion)
+
+### B1 — Schema: `authorizer_trusted_issuers` (unified)
+
+- **DB**: struct with `kind` (`client_assertion_trust`|`sso_saml`|`sso_oidc`, immutable), `org_id` (nullable, immutable, FK), `client_id` (nullable FK), `issuer_url`, `audience`, `expected_subject`, `jwks_url`/`discovery_url`/`pinned_jwks`, `config` (kv map). Only `client_assertion_trust` populated in B; `sso_*` reserved for C. All 6 providers + `Collections`. Index `(kind, org_id, issuer_url)`.
+- **Tests**: round-trip ×6; `kind`/`org_id` immutability guard; `expected_subject` empty ⇒ deny-all.
+
+### B2 — client_assertion resolution (RFC 7523)
+
+- **API**: extend the A3 resolver with `client_assertion` (`client_assertion_type=…jwt-bearer` and `…jwt-spiffe`). **Lookup scoped `WHERE kind='client_assertion_trust' AND org_id IS NULL`** (CR1); reject any other row. Validate: signature against JWKS keyed by trust-row identity (H7); `aud` == exact token-endpoint URL; `exp − iat ≤ ceiling`; single-use `jti` in shared store, or `(sub,iat,exp)` replay key when `jti` absent (H4); subject exact-match by default, anchored patterns only (H3); algorithm allow-list, reject `alg:none` (G8). SSRF hardening on org-supplied URLs already in place from design; issuer URLs globally unique, reject `kubernetes.default.svc` (H5). SPIFFE: validate SPIFFE ID against trust bundle per `draft-ietf-oauth-spiffe-client-auth`.
+- **API**: advertise `private_key_jwt` + `…jwt-spiffe` in discovery `token_endpoint_auth_methods_supported`.
+- **Tests**: K8s projected-token happy path; replay rejected (jti and no-jti); wrong subject rejected; SSO row rejected on this path (CR1); `alg:none` rejected; cross-cluster issuer collision rejected.
+
+### B3 — Admin surface + UI for trusted issuers
+
+- **API**: `_create_trusted_issuer` etc. (platform-super-admin only for `client_assertion_trust`). **UI**: dashboard "Trusted Issuers" page.
+- **Tests**: only super-admin can create `client_assertion_trust`.
+
+---
+
+## Phase C — Organizations, SSO & provisioning
+
+**Hard gate**: FGA `HIGHER_CONSISTENCY` must be plumbed first (MED-1) — add an optional consistency param to `internal/authorization/engine` `CheckRequest`, used for grant checks at token issuance. And an **org-scoped admin permission model** (H1) must exist before org operations.
+
+### C1 — Schema: `authorizer_organizations`, `authorizer_org_memberships`, `authorizer_scim_endpoints`
+
+- **DB**: three tables (design §4.7) ×6 providers + `Collections`. `users` additive: `external_id` (nullable), `is_active` (default true). Unique `(org_id, user_id)` on memberships; unique `org_id` on scim_endpoints.
+- **Tests**: round-trip ×6; membership uniqueness; user additive fields default correctly for existing rows.
+
+### C2 — `(org, client)` grant as FGA tuple + org_id claim
+
+- **API**: grant create requires bidirectional consent (org admin + client owner). `org_id` claim stamped only from an active, consistency-checked grant tuple (`org:<id>#client_grant@client:<id>`), never a request param (C3). `_grant_org_client` / `_revoke_org_client` admin ops.
+- **Tests**: token for un-granted org rejected; revoked grant immediately stops stamping (needs HIGHER_CONSISTENCY); rogue-org-admin cannot pull in a client without owner consent.
+
+### C3 — SSO connections (SAML SP + OIDC) on `trusted_issuers`
+
+- **API**: `sso_saml`/`sso_oidc` rows (org-scoped). SAML SP with the full §4.4 invariants (signature over consumed assertion / XSW defense, unsigned rejected, per-org Audience+Recipient+Destination, NotBefore/NotOnOrAfter+skew, single-use AssertionID cache in shared store, InResponseTo bound to pending AuthnRequest store, IdP-initiated off by default, RelayState allow-listed). OIDC broker with mix-up defense via `iss`/RFC 9207 (G3). Federated identity namespaced `(org_id, issuer, sub)`, no email-only linking. JIT provisioning.
+- **UI**: dashboard per-org connection config (metadata, cert, ACS URL display).
+- **Tests**: valid assertion → session; XSW/unsigned/wrong-audience/replay/cross-org all rejected; mix-up rejected.
+
+### C4 — Inbound SCIM 2.0 server (per org)
+
+- **API**: router group `/scim/v2/…`, SCIM error schema. Endpoints: Users (POST/GET/PUT/PATCH/DELETE-as-active=false), Groups, `/ServiceProviderConfig`, `/Schemas`, `/ResourceTypes`. `userName eq` filtering. `org_id` derived only from the connection bearer token (H6). Group→role mapping bounded to org namespace, unknown groups ignored (CR2). Deactivate/delete synchronously revokes sessions + refresh tokens. Bearer token high-entropy, hashed at rest, constant-time.
+- **UI**: dashboard shows SCIM endpoint URL + rotate-token.
+- **Tests**: Entra/Okta-shaped PATCH deprovision revokes sessions; cross-org mutation rejected; group→platform-role rejected; `userName eq` dedup; discovery endpoints served.
+
+---
+
+## Phase D — Delegation chain (RFC 8693)
+
+### D1 — token-exchange grant
+
+- **API**: `grant_type=…token-exchange` on `/oauth/token`. Requires `actor_token` (delegation-only profile, P3). Nested `act` claim (reserved, guarded against forgery). Effective scope = `requested ∩ subject_token.scope ∩ client.max_scopes` fail-closed, monotonic non-widening (H1). Hard `act`-depth limit. Mandatory single `resource` (RFC 8707, P2) — reject 0 or >1 on the delegated path only. Tokens: RFC 9068 `typ: at+jwt`, `client_id`, `sub`=client for machine tokens (G7). Short child TTL; sensitive scopes require introspection (revocation).
+- **Tests**: delegation narrows scope; re-delegation cannot widen; depth limit enforced; missing/multiple resource rejected; revoked subject token → child introspection fails.
+
+### D2 — RFC 9728 protected-resource metadata
+
+- **API**: `/.well-known/oauth-protected-resource` per protected API; advertises required `aud`. MCP-usable.
+- **Tests**: metadata served; aud contract documented.
+
+---
+
+## Subagent orchestration (build order)
+
+Dependency order is strict: **A → B → C → D**, and within a phase the schema/struct lands and compiles before the parallel per-provider CRUD agents run (they edit different files, no conflict). Pattern per schema-bearing step:
+
+1. **Foundation agent** (sequential): define the struct, `Collections` entry, service interface, GraphQL/proto — commit, build-gate.
+2. **6 provider agents** (parallel, one file each): implement CRUD for their provider against the struct — each build-gates its own package.
+3. **Integration agent** (sequential): wire handlers/resolvers, run `make generate-graphql`, full build + `TEST_DBS=sqlite` test gate, commit.
+
+Every phase ends with the phase's gate (above) green and a commit. Nothing merges to main; the branch is handed to manual testing per `MANUAL_TEST_PLAN.md`.

--- a/specs/machine-agent-identity/MANUAL_TEST_PLAN.md
+++ b/specs/machine-agent-identity/MANUAL_TEST_PLAN.md
@@ -1,0 +1,101 @@
+# Machine & Agent Identity — Manual Test Plan
+
+Run against branch `feat/machine-agent-identity`. Each phase has a **regression** block (existing behavior must be unchanged) and a **new-feature** block with **edge cases**. `[ ]` = check. Expected results are stated; anything else is a bug.
+
+Setup: `make dev` (SQLite, embedded dev keys) unless a phase says otherwise. Note the deployment's `Config.ClientID`/`ClientSecret` — several checks compare against them.
+
+---
+
+## Phase A — Client registry
+
+### A. Regression (must be UNCHANGED)
+- [ ] Existing login (email+password, authorization_code+PKCE) completes; access token issued.
+- [ ] Decode the access token: `aud` == the deployment's `Config.ClientID` (BC1). **Edge:** a token issued *before* the upgrade still validates after it (no forced re-login).
+- [ ] Existing browser session cookie still decrypts after upgrade (BC2). **Edge:** rotate the *client's* stored secret via the new admin API → existing sessions still decrypt (cookie key not coupled).
+- [ ] `GET /.well-known/openid-configuration` — same issuer/endpoints; `grant_types_supported` now additionally lists `client_credentials`. JWKS shape unchanged; `kid` == `Config.ClientID`.
+- [ ] `POST /oauth/introspect` for a live token → `active: true`, `client_id` == `Config.ClientID`, same fields as before.
+- [ ] `POST /oauth/revoke` with a valid refresh token → `200 {}`; token no longer works. **Edge:** revoke with a garbage token → still `200 {}` (no oracle).
+- [ ] `/graphql` with **no** `X-Authorizer-Client-ID` header still works (back-compat allowance).
+
+### B. New feature: client registry
+- [ ] Boot the server twice → exactly one reserved client row exists (idempotent seed). **Edge:** start two instances at once → still one row (no duplicate).
+- [ ] Admin creates an `interactive` client via `_create_client`; secret revealed exactly once. **Edge:** fetch/list it again → secret/hash never present in the response.
+- [ ] Admin creates a `service_account` client; **Edge:** attempt `_update_client` to change `kind` → rejected (immutable).
+- [ ] Create a client with an admin-supplied `client_id` → that exact id is used. **Edge:** supply a `client_id` that already exists → rejected (unique).
+- [ ] Create a public `interactive` client (no secret) → PKCE required on its authorize flow; **Edge:** authorization_code without PKCE for it → rejected.
+
+### C. New feature: client_credentials
+- [ ] `service_account` authenticates at `/oauth/token` (grant `client_credentials`) with its revealed secret → token issued, no refresh token (RFC 6749 §4.4.3). **Edge:** request a scope outside `max_scopes` → rejected. **Edge:** wrong secret → `invalid_client`, and timing is indistinguishable from an unknown client (constant-time).
+- [ ] **Edge:** present BOTH `client_secret_post` and a `client_assertion` in one request → rejected (RFC 6749 §2.3).
+- [ ] Failed `client_credentials` writes an audit event `token.client_credentials_failed`; success writes `token.client_credentials`.
+
+---
+
+## Phase B — Secretless client auth (K8s / SPIFFE)
+
+Setup: a `client_assertion_trust` row bound to a test issuer (a local JWKS you control), `expected_subject` pinned, `audience` == token-endpoint URL.
+
+### Regression
+- [ ] All Phase A checks still pass.
+
+### New feature + edge cases
+- [ ] Present a valid signed assertion (correct iss/aud/sub/exp) as `client_assertion` → authenticated, token issued.
+- [ ] **Edge (CR1, the critical):** create an `sso_oidc` row for an org at the *same issuer URL*; present a token from it as a `client_assertion` → **rejected** (lookup is `kind=client_assertion_trust` scoped; the SSO row must never authenticate a client).
+- [ ] **Edge (replay, H4):** replay the same assertion twice → second rejected (`jti` single-use, or `(sub,iat,exp)` key when no `jti`).
+- [ ] **Edge (H3):** assertion with a subject that only prefix-matches the pinned pattern (e.g. `prod-evil` vs `prod`) → rejected (exact/anchored match).
+- [ ] **Edge:** `expected_subject` left empty on the row → the row is deny-all (no assertion authenticates).
+- [ ] **Edge (H4 lifetime):** assertion with `iat` far in the past but near-future `exp` → rejected (`exp − iat` exceeds ceiling).
+- [ ] **Edge (G8):** assertion signed with `alg:none` → rejected.
+- [ ] **Edge (aud):** assertion whose `aud` is a generic issuer string, not the exact token-endpoint URL → rejected.
+- [ ] **Edge (H5):** issuer URL `https://kubernetes.default.svc` → rejected at row creation (must be globally unique/external).
+- [ ] Only a platform super-admin can create a `client_assertion_trust` row; an org admin cannot.
+
+---
+
+## Phase C — Organizations, SSO, SCIM
+
+### Regression
+- [ ] All Phase A/B checks still pass; global (non-org) users unaffected.
+
+### C1 Organizations & membership
+- [ ] Create org, add a user as member with a per-org role. **Edge:** add the same user twice → rejected (unique `(org_id, user_id)`). **Edge:** same user is admin in Org A, viewer in Org B → both roles independent.
+
+### C2 (org, client) M2M grant
+- [ ] Grant a `service_account` client to Org A → its `client_credentials` token now carries `org_id: A`. **Edge (C3):** request a token with `organization=B` for a client granted only to A → rejected (org_id from the grant, not the request).
+- [ ] **Edge (MED-1):** revoke the grant, immediately request a token → `org_id` no longer stamped (requires HIGHER_CONSISTENCY; if it still stamps for a window, that's the bug this gate exists for).
+- [ ] **Edge (bidirectional consent):** an Org-A admin tries to grant a client they don't own without the client owner's opt-in → rejected.
+
+### C3 SSO (SAML SP + OIDC)
+- [ ] Configure an org SAML connection; a valid signed assertion logs a user in and JIT-provisions. **Edge (XSW):** an assertion where the signature covers a different element than the consumed one → rejected. **Edge:** unsigned assertion → rejected. **Edge:** assertion with Org B's Audience presented at Org A's ACS → rejected. **Edge:** replay the same AssertionID → rejected. **Edge:** SP-initiated response with a mismatched/absent InResponseTo → rejected.
+- [ ] OIDC org connection logs in. **Edge (mix-up, G3):** a response bearing a different `iss` than the connection dispatched to → rejected.
+- [ ] **Edge (account takeover):** an org IdP asserts an `email` that collides with an existing global user → NOT silently linked (namespaced `(org_id, issuer, sub)`).
+
+### C4 Inbound SCIM
+- [ ] Provision a user via SCIM POST with the org's bearer token → user created with `external_id`. **Edge (dedup):** IdP does `GET /Users?filter=userName eq "x"` before create → returns the existing user, no duplicate.
+- [ ] Deprovision via `PATCH active:false` → user disabled AND active sessions/refresh tokens revoked **immediately**. **Edge:** the deprovisioned user's still-held access token fails introspection.
+- [ ] **Edge (CR2):** a SCIM group that maps to a platform/global role → rejected/ignored (org-namespaced roles only).
+- [ ] **Edge (H6):** use Org A's SCIM token to mutate an Org B user (via id in the path/payload) → rejected (org derived from token only).
+- [ ] `/ServiceProviderConfig`, `/Schemas`, `/ResourceTypes` served. **Edge:** bad bearer token → `401`, constant-time.
+
+---
+
+## Phase D — Delegation (token exchange)
+
+### Regression
+- [ ] All prior checks pass.
+
+### New feature + edge cases
+- [ ] `grant_type=token-exchange` with subject_token + actor_token + one `resource` → new token with nested `act`, audience-bound. **Edge:** omit `actor_token` → rejected (delegation-only profile). **Edge:** omit `resource` or pass two → rejected (single-resource profile).
+- [ ] **Edge (attenuation, H1):** request a scope broader than the subject_token's scope → narrowed to the intersection, never widened. **Edge:** re-exchange a delegated token requesting the original broad scope → still cannot widen.
+- [ ] **Edge (depth):** build an `act` chain past the configured depth limit → rejected.
+- [ ] Token carries `typ: at+jwt` and `client_id` (RFC 9068). **Edge (revocation):** revoke the subject token → a child token's introspection for a sensitive scope returns `active:false`.
+- [ ] `/.well-known/oauth-protected-resource` served for a protected API with the required `aud`.
+
+---
+
+## Cross-cutting (run after all phases)
+- [ ] `make test` (full sqlite suite) green.
+- [ ] `make test-all-db` green across all 7 backends.
+- [ ] `make lint` clean.
+- [ ] Multi-instance: run 2 instances sharing Redis (`TEST_ENABLE_REDIS=1` style) → jti replay rejected across instances; a client disabled on instance 1 is rejected on instance 2 within the cache TTL.
+- [ ] No secret/hash ever appears in any GraphQL/REST/gRPC response, any log line, or any webhook payload (grep the audit/webhook logs).

--- a/specs/machine-agent-identity/SUBAGENT_GUIDE.md
+++ b/specs/machine-agent-identity/SUBAGENT_GUIDE.md
@@ -1,0 +1,74 @@
+# Subagent Guide — PR pipeline for machine-agent-identity
+
+How every PR in this program is planned, built, tested, reviewed, and shipped. Read this + `IMPLEMENTATION_PLAN.md` + `MANUAL_TEST_PLAN.md` before starting any PR.
+
+## The non-negotiable dependency reality
+
+These PRs form a **stack**, not 8 independent parallel merges — each builds on the prior's code:
+
+```
+main
+ └─ PR1  Client registry: schema + storage (6 providers) + service layer
+     └─ PR2  Client registry API: GraphQL _client_* + gRPC admin + kind-aware projection
+         └─ PR3  Resolver + client_credentials + discovery metadata + BC1/BC2/BC3 + refresh rotation
+             └─ PR4  Secretless auth: TrustedIssuer client_assertion + SPIFFE + K8s  (Phase B)
+                 └─ PR5  Organizations + memberships + (org,client) FGA grant + HIGHER_CONSISTENCY  (Phase C1/C2)
+                     ├─ PR6  SSO: SAML SP + OIDC broker  (Phase C3)   ← PR6 and PR7 are independent of each other
+                     └─ PR7  Inbound SCIM 2.0 server     (Phase C4)   ← both depend on PR5, not on each other
+                         └─ PR8  Delegation: token exchange (RFC 8693)  (Phase D)
+```
+
+**Where parallelism is safe:**
+- **Within a PR**: the 6 storage providers (sql, mongodb, arangodb, cassandradb, dynamodb, couchbase) are separate files — fan out one agent per provider *after* the shared struct/interface lands.
+- **PR6 (SSO) and PR7 (SCIM)** both depend only on PR5 (orgs) and touch different code — they can be authored in parallel worktrees off PR5's branch.
+- Everything else is sequential: a PR's branch is based on its parent PR's branch (stacked), and each targets `main` (or, if the parent isn't merged yet, retarget once it is). Do NOT base a PR on `main` if it needs a parent PR's code.
+
+## Base branches
+
+- PR1 branches off `origin/main`.
+- PRn (n>1) branches off PR(n-1)'s branch. When PR(n-1) merges to main, rebase PRn onto main and retarget the PR base to `main`.
+- The current `feat/machine-agent-identity` branch already contains PR1+PR2+part of PR3 material (the merged phase-1 work + the Client rename). PR1/PR2 are carved out of it.
+
+## SDLC every PR follows (owned by a `principal-engineer` lead agent)
+
+1. **Plan** — write a 10-line plan comment on the PR scope: what changes (DB/API/UI), which files, which edge cases from `MANUAL_TEST_PLAN.md` it must cover, what it explicitly defers. Post it in the PR description.
+2. **Implement** — on the PR branch, honoring every ground rule below. Schema-bearing PRs: land the struct + `Collections` entry + `Provider` interface first (sequential), THEN fan out per-provider CRUD agents, THEN an integration agent wires handlers/resolvers + runs codegen.
+3. **Test** — unit + integration; add regression tests for this PR's edge cases (name them after the finding, e.g. `TestClientAssertion_SSORowRejected` for CR1). `TEST_DBS=sqlite go test -p 1 ./internal/...` green locally; the PR's CI runs the rest.
+4. **Review** — dispatch a `security-engineer` pass AND a `principal-engineer` (second-pair) pass on the diff. Every CRITICAL/HIGH/BLOCKER is fixed before requesting human review; SHOULD-FIX either fixed or explicitly deferred with a reason in the PR.
+5. **Iterate** — loop 3–4 until build + `make lint` + tests are green and reviews are clean. Then open/update the PR.
+
+## Ground rules (hard gates — a PR is not done until all hold)
+
+- **Never commit to `main`. Never merge. Never force-push a shared branch.** Open the PR; a human merges.
+- **Never** weaken the Rev.5 security fixes. The design doc §5.2 findings (BC1–BC3, CR1–CR3, H1–H7, G-gaps) are requirements, not suggestions. Each PR's tests must prove its relevant findings are closed (see `MANUAL_TEST_PLAN.md`).
+- Schema change ⇒ all 6 providers + `Collections` + per-provider migration/index. Add a round-trip test asserting every field (incl. any `json:"-"` secret) persists and never serializes out.
+- `make generate-graphql` after `schema.graphqls`; `make proto-gen` after `proto/`; commit generated output; PR must have zero codegen drift.
+- Transports thin; logic in `internal/service/` behind a `Provider` interface. Admin GraphQL ops `_`-prefixed. Constants in `internal/constants` (no literals in dispatch). gin-context error pattern (#638/#639); fire-and-forget goroutines use `context.WithoutCancel`. Audit events dotted `<actor>.<action>`, success + failure.
+- Single-use caches (`jti`, SAML AssertionID, OAuth code) and the authoritative client cache live in the shared `memory_store` (Redis), invalidated cross-instance.
+- **Build gate**: `go build ./... && make lint-go && go vet ./...`. **Test gate**: `TEST_DBS=sqlite go test -p 1 ./internal/...`. **Full gate before marking ready**: `make test-all-db` green (or CI equivalent).
+- Commit messages: conventional, no Co-Authored-By, no AI attribution. PR descriptions: no AI-branding.
+
+## Per-PR scope (summary — full detail in IMPLEMENTATION_PLAN.md)
+
+| PR | Scope | Key edge-case tests |
+|----|-------|---------------------|
+| PR1 | `Client` schema + `Collections` + 6-provider CRUD + service layer | round-trip persists secret + never leaks; unique client_id; kind default |
+| PR2 | `_client_*` GraphQL + gRPC admin, kind-aware projection, one-time secret reveal, admin-suppliable client_id | secret never in get/list; kind immutable; dup client_id rejected |
+| PR3 | resolver (secret/basic/none), `client_credentials`, discovery metadata, BC1/BC2/BC3, refresh rotation | existing token/session unchanged (BC1/BC2); dual-auth rejected; scope-subset |
+| PR4 | TrustedIssuer client_assertion, SPIFFE, K8s | CR1 SSO-row rejected; replay; subject exact-match; alg:none; issuer collision |
+| PR5 | Organizations, memberships, (org,client) FGA grant, HIGHER_CONSISTENCY | C3 org from grant not request; revoked grant stops stamping; membership unique |
+| PR6 | SAML SP + OIDC broker | XSW; unsigned; cross-org audience; replay; mix-up (iss); no email-only link |
+| PR7 | Inbound SCIM 2.0 | CR2 platform-role rejected; H6 cross-org mutation rejected; deprovision revokes sessions |
+| PR8 | token exchange (RFC 8693) | attenuation non-widening; depth limit; single resource; revocation via introspection |
+
+## Orchestration order (what the coordinator dispatches)
+
+1. Gate: `make test-all-db` green on `feat/machine-agent-identity` (the current base). ← do this FIRST.
+2. Carve PR1 and PR2 from the current branch, open them (stacked), run their review passes.
+3. PR3 on top; review.
+4. PR4 on top; review (security-heavy).
+5. PR5 on top; review.
+6. PR6 + PR7 in parallel worktrees off PR5; review each.
+7. PR8 on top of PR5 (after PR6/PR7 or in parallel — it doesn't touch SSO/SCIM); review.
+
+The coordinator verifies each PR's gates itself before opening it — never trust a subagent's self-report on a security-critical PR without re-running build + the relevant tests.


### PR DESCRIPTION
## What

Part 1 of the post-MAI docs cleanup: specs live in this repo only.

- Import design/build specs from the server repo (per existing convention — FGA, delegation specs already live here):
  - `specs/GRPC_REST_API_SPEC.md` (was `docs/grpc-rest-api-spec.md`)
  - `specs/WORKLOAD_IDENTITY_PROGRAM.md` (was `docs/specs/WORKLOAD_IDENTITY_PROGRAM.md`)
  - `specs/machine-agent-identity/` (implementation plan, manual test plan, subagent guide)
- Merge the unique content of the server repo's `docs/enterprise-oidc-idp-integration.md` into `core/oauth2-oidc.md` before it gets deleted there: nonce handling, response modes + form_post CSP, PKCE `plain` default, client auth methods, 10-min code TTL, new troubleshooting rows.
- Fix two stale claims found while merging (verified against server source):
  - PKCE supports `S256` **and** `plain`; `plain` is the default when the method is omitted (RFC 7636 §4.2, `authorize.go:154-170`)
  - `token_endpoint_auth_methods_supported` includes `none` and `private_key_jwt` (`openid_config.go:60`)

## Testing

- `npx docusaurus build` passes.

Companion server-repo PR removes the now-duplicated files.