### PR TITLE
docs: MAI enterprise docs, OAuth reference update

### DIFF
--- a/docs/core/client-registry.md
+++ b/docs/core/client-registry.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 6
+title: Client Registry
+---
+
+# Client Registry
+
+Authorizer maintains a **client registry** — one authoritative table of every OAuth client that can authenticate against the instance. It holds two kinds of clients:
+
+| Kind | What it is | Grants |
+|------|------------|--------|
+| `interactive` | Human-facing login client (browser/app redirect flows). The instance's **reserved client** — seeded at boot from `--client-id` / `--client-secret` — is this kind. | `authorization_code`, `refresh_token` |
+| `service_account` | Machine/workload identity (backend services, CI jobs, AI agents). Created by admins via the admin API. | `client_credentials`, [token exchange](../enterprise/token-exchange) |
+
+`kind` is **immutable** after creation. Clients created through the admin API today are `service_account` clients; the interactive kind is currently reserved for the boot-seeded client, so existing single-client deployments keep working unchanged.
+
+## `client_id` vs. internal `id`
+
+Every client has two identifiers:
+
+- **`id`** — the internal surrogate primary key (UUID). Used to address the client in admin operations (`_update_client`, `_rotate_client_secret`, …).
+- **`client_id`** — the public OAuth identifier presented at `/authorize` and `/oauth/token`. Unique across the registry and **immutable**.
+
+For admin-created clients, `client_id` defaults to the internal `id` — the UUID returned by `_create_client` is the value you pass as `client_id` at the token endpoint. For the reserved boot client, `client_id` is the literal `--client-id` value, so every existing token `aud`, JWKS `kid`, and introspection `client_id` keeps keying on that exact string.
+
+## Client secrets
+
+- Generated server-side; stored only as a **bcrypt hash** (cost 12).
+- The plaintext is returned **exactly once** — in the `_create_client` response and again in the `_rotate_client_secret` response. It can never be retrieved afterwards; store it in your secret manager immediately.
+- Rotating a client's secret does **not** affect browser session-cookie encryption (that stays bound to the instance's `--client-secret`).
+- Secret verification is constant-time; an unknown `client_id` and a wrong secret are indistinguishable to a caller.
+
+## Scopes are an allow-list
+
+`allowed_scopes` is the client's authorization ceiling:
+
+- A `client_credentials` request may only ask for a **subset** of `allowed_scopes`; anything outside it fails with `invalid_scope` (no silent downgrade).
+- Omitting `scope` grants the full authorized set.
+- An **empty allow-list is deny-all** — `_create_client` requires at least one non-empty scope.
+- In [token exchange](../enterprise/token-exchange), `allowed_scopes` is the agent's delegation ceiling.
+
+## Admin API
+
+All operations require super-admin authentication (`x-authorizer-admin-secret` header or the `authorizer.admin` cookie from `_admin_login`) and are also available over gRPC/REST via `AuthorizerAdminService` (`CreateClient`, `UpdateClient`, `DeleteClient`, `RotateClientSecret`, `GetClient`, `Clients` — see the [gRPC reference](./grpc)).
+
+| Operation | Type | Purpose |
+|-----------|------|---------|
+| `_create_client` | mutation | Register a service account; returns the secret **once** |
+| `_update_client` | mutation | Update `name`, `description`, `allowed_scopes`, `is_active` |
+| `_rotate_client_secret` | mutation | Invalidate the old secret, return a new one **once** |
+| `_delete_client` | mutation | Remove the client |
+| `_client` | query | Fetch one client by `id` |
+| `_clients` | query | Paginated list |
+
+### Create a service account
+
+```graphql
+mutation {
+  _create_client(
+    params: {
+      name: "payments-worker"
+      description: "Nightly settlement job"
+      allowed_scopes: ["read:payments", "write:settlements"]
+    }
+  ) {
+    client {
+      id
+      name
+      allowed_scopes
+      is_active
+    }
+    client_secret # shown ONCE — store it now
+  }
+}
+```
+
+### Manage clients
+
+```graphql
+# Disable a client (blocks new token issuance immediately;
+# already-issued tokens live until their exp)
+mutation {
+  _update_client(params: { id: "CLIENT_UUID", is_active: false }) {
+    id
+    is_active
+  }
+}
+
+# Rotate the secret
+mutation {
+  _rotate_client_secret(params: { id: "CLIENT_UUID" }) {
+    client { id }
+    client_secret # the new secret, shown ONCE
+  }
+}
+
+# List
+query {
+  _clients {
+    pagination { total }
+    clients { id name allowed_scopes is_active created_at }
+  }
+}
+```
+
+Client responses never contain a secret or secret hash — there is no `client_secret` field on the `Client` type by design.
+
+## Authenticating: `client_credentials`
+
+Service accounts get tokens with the RFC 6749 §4.4 grant at `POST /oauth/token`:
+
+```bash
+curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "scope=read:payments"
+```
+
+```json
+{
+  "access_token": "eyJhbG...",
+  "token_type": "Bearer",
+  "expires_in": 1800,
+  "scope": "read:payments"
+}
+```
+
+Rules:
+
+- Client authentication via `client_secret_basic` (HTTP Basic) or `client_secret_post` (form body) — never both; presenting more than one method is rejected (RFC 6749 §2.3).
+- The grant is **machine-only**: an interactive `client_id` is rejected with `unauthorized_client` before secret verification, so it can't be used to confirm a guessed secret.
+- No `refresh_token`, no `id_token` — re-authenticate on expiry.
+- Discovery (`/.well-known/openid-configuration`) advertises `client_credentials` in `grant_types_supported`.
+- Success and failure are both audited (`token.client_credentials` / `token.client_credentials_failed` audit events).
+
+## Secretless authentication: client assertions & trusted issuers
+
+Instead of a stored secret, a service account can authenticate with a signed JWT it already possesses — a Kubernetes ServiceAccount token or a SPIFFE JWT-SVID — presented as an RFC 7523 `client_assertion`:
+
+```
+POST /oauth/token
+grant_type=client_credentials
+&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+&client_assertion=<external JWT>
+```
+
+The assertion is validated against a **trusted issuer** the admin registers for that service account (`_add_trusted_issuer` / `_update_trusted_issuer` / `_delete_trusted_issuer` / `_trusted_issuer` / `_trusted_issuers`): issuer URL, key source (OIDC discovery or a static JWKS URL), expected audience, and an exact-match subject allow-list (empty = deny-all).
+
+Setup, validation rules, and Kubernetes/SPIFFE walkthroughs: [Workload Identity](../enterprise/workload-identity).
+
+## Backward compatibility
+
+The registry is additive. On upgrade:
+
+- The reserved client is seeded idempotently from `--client-id` / `--client-secret` (booting twice, or two instances at once, still yields one row).
+- Existing tokens keep validating; `aud` stays the configured `--client-id`.
+- Existing session cookies keep decrypting; cookie crypto is not coupled to per-client secrets.
+- Discovery and JWKS shapes are unchanged.

--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -22,12 +22,15 @@ This page is the one-stop reference for every endpoint, parameter, and integrati
 | OIDC Hybrid Flow (§3.3)               | Implemented   | `code id_token`, `code token`, `code id_token token`, `id_token token` |
 | OIDC RP-Initiated Logout 1.0          | Implemented   | `post_logout_redirect_uri`, `state` echo, `id_token_hint`          |
 | OIDC Back-Channel Logout 1.0          | Implemented   | Opt-in via `--backchannel-logout-uri`                              |
-| RFC 6749 (OAuth 2.0)                  | Implemented   | Authorization Code + Refresh Token + Implicit grants               |
+| RFC 6749 (OAuth 2.0)                  | Implemented   | Authorization Code + Refresh Token + Implicit + Client Credentials grants |
 | RFC 6750 (Bearer Token)               | Implemented   | `WWW-Authenticate` on 401                                          |
 | RFC 7009 (Token Revocation)           | Implemented   | Returns 200 for invalid tokens                                     |
 | RFC 7517 (JWK)                        | Implemented   | RSA, ECDSA, HMAC; manual multi-key rotation                        |
+| RFC 7523 (JWT client assertions)      | Implemented   | `private_key_jwt` via [trusted issuers](../enterprise/workload-identity) — K8s SA tokens, SPIFFE JWT-SVIDs |
 | RFC 7636 (PKCE)                       | Implemented   | `S256` and `plain` methods; defaults to `plain` when the method is omitted (§4.2) |
 | RFC 7662 (Token Introspection)        | Implemented   | Non-disclosure for inactive tokens                                 |
+| RFC 8693 (Token Exchange)             | Implemented   | [Delegation-only profile](../enterprise/token-exchange) with nested `act` chain |
+| RFC 8707 (Resource Indicators)        | Implemented   | `resource` binding on the token-exchange grant (exactly one required) |
 
 **Not yet implemented** (tracked for future releases): RFC 7591 dynamic client registration, RFC 9101 JAR / Request Object, OIDC Session Management iframe, front-channel logout, automated time-based key rotation.
 
@@ -406,7 +409,7 @@ Returns metadata so clients can auto-configure themselves.
 | `revocation_endpoint`                                 | URL for `/oauth/revoke`                                                              |
 | `end_session_endpoint`                                | URL for `/logout`                                                                    |
 | `response_types_supported`                            | `["code", "token", "id_token", "code id_token", "code token", "code id_token token", "id_token token"]` |
-| `grant_types_supported`                               | `["authorization_code", "refresh_token", "implicit"]`                                |
+| `grant_types_supported`                               | `["authorization_code", "refresh_token", "client_credentials", "implicit", "urn:ietf:params:oauth:grant-type:token-exchange"]` |
 | `scopes_supported`                                    | `["openid", "email", "profile", "offline_access"]`                                   |
 | `response_modes_supported`                            | `["query", "fragment", "form_post", "web_message"]`                                  |
 | `code_challenge_methods_supported`                    | `["S256", "plain"]`                                                                  |
@@ -502,9 +505,9 @@ For `form_post`, Authorizer serves the auto-submitting form with a dedicated `Co
 ### Token Endpoint
 
 **Endpoint:** `POST /oauth/token`
-**Specs:** [RFC 6749 §3.2](https://www.rfc-editor.org/rfc/rfc6749#section-3.2) | [RFC 7636 §4.6](https://www.rfc-editor.org/rfc/rfc7636#section-4.6)
+**Specs:** [RFC 6749 §3.2](https://www.rfc-editor.org/rfc/rfc6749#section-3.2) | [RFC 7636 §4.6](https://www.rfc-editor.org/rfc/rfc7636#section-4.6) | [RFC 8693](https://www.rfc-editor.org/rfc/rfc8693)
 
-Exchanges an authorization code or refresh token for access / ID tokens.
+Serves four grant types: `authorization_code`, `refresh_token`, `client_credentials`, and `urn:ietf:params:oauth:grant-type:token-exchange`.
 
 **Content-Type:** `application/x-www-form-urlencoded` or `application/json`
 **Response headers:** `Cache-Control: no-store`, `Pragma: no-cache` (RFC 6749 §5.1)
@@ -546,13 +549,52 @@ Refresh tokens are **rotated** on each use — the old one is invalidated and a 
 }
 ```
 
+**Client Credentials grant** (RFC 6749 §4.4 — machine/service-account tokens):
+
+| Parameter       | Required | Notes                                                                    |
+| --------------- | -------- | ------------------------------------------------------------------------ |
+| `grant_type`    | Yes      | `client_credentials`                                                     |
+| `client_id`     | Yes      | A `service_account` client from the [client registry](./client-registry) |
+| `client_secret` | Yes\*    | Via HTTP Basic (`client_secret_basic`) or form body (`client_secret_post`) |
+| `scope`         | No       | Space-separated subset of the client's `allowed_scopes`. Omitted = full authorized set. Any scope outside the allow-list rejects the whole request with `invalid_scope` |
+
+\*Instead of a secret, the client may authenticate with an RFC 7523 `client_assertion` — see [Workload Identity](../enterprise/workload-identity). Presenting more than one authentication method is rejected (RFC 6749 §2.3). Interactive clients (including the reserved boot client) are rejected on this grant with `unauthorized_client`.
+
+```bash
+curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -u "$SERVICE_ACCOUNT_ID:$SERVICE_ACCOUNT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "scope=read:reports"
+```
+
+```json
+{ "access_token": "eyJhbG...", "token_type": "Bearer", "expires_in": 1800, "scope": "read:reports" }
+```
+
+No `id_token` and no `refresh_token` are issued — machines re-authenticate on expiry (RFC 6749 §4.4.3). See the [Client Registry guide](./client-registry) for the full flow.
+
+**Token Exchange grant** (RFC 8693 — delegation only):
+
+| Parameter            | Required | Notes                                                                    |
+| -------------------- | -------- | ------------------------------------------------------------------------ |
+| `grant_type`         | Yes      | `urn:ietf:params:oauth:grant-type:token-exchange`                        |
+| `subject_token`      | Yes      | The user's access token (the authority being exercised)                  |
+| `subject_token_type` | Yes      | `urn:ietf:params:oauth:token-type:access_token` or `...:jwt`             |
+| `actor_token`        | Yes      | The agent's own access token (delegation-only — omitting it is rejected) |
+| `actor_token_type`   | Yes      | Same URNs as `subject_token_type`                                        |
+| `resource`           | Yes      | Exactly one (RFC 8707) — 0 or >1 values are rejected                     |
+| `scope`              | No       | Requested down-scope; the result is always the intersection with the subject's scope and the agent's ceiling |
+
+The calling client must authenticate as a `service_account` (secret or `client_assertion`). The resulting token is short-lived (5 minutes), audience-bound to `resource`, and carries the nested `act` actor chain. Full semantics, security invariants, and examples: [Token Exchange & Delegation](../enterprise/token-exchange).
+
 **Error response:**
 
 ```json
 { "error": "invalid_grant", "error_description": "..." }
 ```
 
-Standard codes: `invalid_request`, `invalid_client`, `invalid_grant`, `unsupported_grant_type`, `invalid_scope`.
+Standard codes: `invalid_request`, `invalid_client`, `invalid_grant`, `unsupported_grant_type`, `unauthorized_client`, `invalid_scope`.
 
 ### UserInfo Endpoint
 

--- a/docs/core/sso-guide.md
+++ b/docs/core/sso-guide.md
@@ -295,28 +295,49 @@ For detailed endpoint documentation, see the [OAuth 2.0 & OIDC reference](/core/
 
 ---
 
+## Enterprise & Workload Identity Features
+
+Several capabilities that used to live on this page's roadmap have shipped. Each has its own reference page:
+
+### Client Registry (Multiple Clients)
+
+Authorizer maintains a client registry: admins can register additional clients — machine service accounts with their own `client_id`, one-time-revealed `client_secret`, and a per-client scope allow-list — alongside the reserved interactive client. Service accounts authenticate via the OAuth2 `client_credentials` grant. See the [Client Registry guide](./client-registry).
+
+> Programmatic *self-service* registration (RFC 7591 Dynamic Client Registration) is still on the roadmap — today clients are registered by an admin via the admin API or dashboard.
+
+### Organizations
+
+Model tenants as organizations with per-org members and per-org roles, and attach per-org SSO and SCIM connections to them. See [Organizations](../enterprise/organizations).
+
+### Per-Organization SAML 2.0 SSO (SP)
+
+Authorizer acts as a SAML 2.0 Service Provider per organization: register a corporate IdP's entity ID, SSO URL, and signing certificate, and that org's users log in through their IdP with JIT provisioning. See [SAML SSO](../enterprise/org-saml).
+
+### Per-Organization OIDC SSO (Broker)
+
+The OIDC sibling of the SAML SP: Authorizer brokers a per-org upstream OIDC IdP (Okta, Entra ID, Google Workspace) as a Relying Party. See [OIDC SSO](../enterprise/org-sso-oidc).
+
+### SCIM 2.0 Provisioning (RFC 7644)
+
+Per-org inbound SCIM 2.0 endpoints let enterprise directories (Okta, Microsoft Entra ID, OneLogin) provision and deprovision users automatically. Deactivation synchronously revokes sessions and refresh tokens. See [SCIM Provisioning](../enterprise/scim).
+
+### Workload Identity & Delegation
+
+Machines can authenticate without stored secrets (Kubernetes ServiceAccount tokens, SPIFFE JWT-SVIDs — see [Workload Identity](../enterprise/workload-identity)), and agents can act on behalf of users with attenuated, audience-bound tokens via RFC 8693 token exchange (see [Token Exchange](../enterprise/token-exchange)).
+
+---
+
 ## Future Roadmap
 
-The following capabilities are planned for future releases to make Authorizer an even more complete enterprise SSO platform:
+Still planned for future releases:
 
 ### Dynamic Client Registration (RFC 7591)
 
-Today, all apps share the same `client_id` and `client_secret` per Authorizer instance. Dynamic client registration will allow each app to register its own credentials programmatically, enabling:
-- Per-app client credentials with independent secrets
-- Granular per-app token lifetimes and scopes
-- Self-service app onboarding without server restarts
-
-### SAML 2.0 Support
-
-SAML remains widely used in enterprise environments, especially for legacy apps and SaaS tools that don't support OIDC. Adding SAML IdP capabilities will let Authorizer federate with SAML-only service providers.
+Self-service programmatic client registration (the `registration_endpoint`). Today, new clients are created by an admin through the [client registry](./client-registry) admin API.
 
 ### LDAP / Active Directory Integration
 
 Direct LDAP/AD integration will allow Authorizer to authenticate users against existing corporate directories without requiring federation through Azure AD or Google Workspace.
-
-### Multi-Tenant Support
-
-True multi-tenancy with tenant-level data isolation, per-tenant branding, and per-tenant configuration. This will enable SaaS providers to use a single Authorizer deployment for all their customers.
 
 ### Front-Channel Logout (OIDC)
 
@@ -324,11 +345,7 @@ In addition to the already-supported backchannel logout, front-channel logout wi
 
 ### Automated JWKS Key Rotation
 
-Time-based automatic rotation of JWT signing keys with configurable rotation periods, eliminating the need for manual key rotation.
-
-### SCIM Provisioning (RFC 7644)
-
-System for Cross-domain Identity Management will enable automatic user provisioning and deprovisioning from enterprise directories (Azure AD, Okta, OneLogin) into Authorizer.
+Time-based automatic rotation of JWT signing keys with configurable rotation periods, eliminating the need for manual key rotation. (Zero-downtime *manual* rotation via secondary keys is already supported — see the [OAuth 2.0 & OIDC reference](/core/oauth2-oidc).)
 
 ---
 
@@ -339,10 +356,16 @@ Authorizer gives you a **self-hosted, single-binary SSO server** that speaks sta
 | What You Get Today | What's Coming |
 |---|---|
 | Full OIDC IdP with discovery | Dynamic client registration (RFC 7591) |
-| 10+ social login providers | SAML 2.0 IdP |
-| MFA (TOTP, email OTP, SMS OTP) | LDAP/AD integration |
-| RBAC with JWT claims | Multi-tenant support |
-| Backchannel logout | Front-channel logout |
-| Token introspection & revocation | Automated JWKS rotation |
-| 13+ database backends | SCIM provisioning |
+| 10+ social login providers | LDAP/AD integration |
+| MFA (TOTP, email OTP, SMS OTP) | Front-channel logout |
+| RBAC with JWT claims | Automated JWKS rotation |
+| Backchannel logout | |
+| Token introspection & revocation | |
+| 13+ database backends | |
 | Custom access token scripts | |
+| [Client registry](./client-registry) + `client_credentials` grant | |
+| [Organizations](../enterprise/organizations) with per-org members & roles | |
+| [Per-org SAML 2.0 SP](../enterprise/org-saml) & [OIDC broker SSO](../enterprise/org-sso-oidc) | |
+| [SCIM 2.0 provisioning](../enterprise/scim) | |
+| [Workload identity](../enterprise/workload-identity) (K8s, SPIFFE) | |
+| [RFC 8693 token exchange](../enterprise/token-exchange) (delegation) | |

--- a/docs/enterprise/org-saml.md
+++ b/docs/enterprise/org-saml.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 3
+title: Per-Org SAML 2.0 SSO
+---
+
+# Per-Organization SAML 2.0 SSO (Service Provider)
+
+For [organizations](./organizations) whose IdP speaks SAML 2.0 (Okta, Microsoft Entra ID, ADFS, …), Authorizer acts as a **SAML Service Provider (SP)** per org. Users authenticate at the corporate IdP; Authorizer validates the signed assertion, JIT-provisions the user, and issues a normal Authorizer session.
+
+## Endpoints (per org)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/oauth/saml/{org_slug}/metadata` | GET | SP metadata XML — import this at the IdP |
+| `/oauth/saml/{org_slug}/login` | GET | Start an SP-initiated login (sends the AuthnRequest via HTTP-Redirect) |
+| `/oauth/saml/{org_slug}/acs` | POST | Assertion Consumer Service — the IdP posts the SAML response here |
+
+## Setup
+
+### 1. Collect the IdP's details
+
+From the org's IdP you need: the **entity ID** (the assertion `Issuer`), the **SSO URL** (HTTP-Redirect binding), and the **X.509 signing certificate** (PEM).
+
+### 2. Create the connection (admin API)
+
+```graphql
+mutation {
+  _create_org_saml_connection(
+    params: {
+      org_id: "ORG_ID"
+      name: "Acme ADFS"
+      idp_entity_id: "http://adfs.acme.com/adfs/services/trust"
+      idp_sso_url: "https://adfs.acme.com/adfs/ls/"
+      idp_certificate: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+      # sp_entity_id / acs_url: optional overrides; derived from the request
+      # host when omitted:
+      #   sp_entity_id → https://{host}/oauth/saml/{org_slug}/metadata
+      #   acs_url      → https://{host}/oauth/saml/{org_slug}/acs
+      # attribute_mapping: optional JSON, e.g.
+      #   "{\"email\":\"email\",\"given_name\":\"firstName\"}"
+      # allow_idp_initiated: defaults to false (SP-initiated only)
+    }
+  ) {
+    id
+    org_id
+    idp_entity_id
+    sp_entity_id
+    acs_url
+    is_active
+  }
+}
+```
+
+Related operations: `_update_org_saml_connection` (supplying `idp_certificate` replaces it; omitting leaves it intact), `_delete_org_saml_connection`, `_org_saml_connection` (fetch by `id` **or** `org_id`). The IdP certificate is accepted on write but never projected back.
+
+The `idp_entity_id` is globally unique across all trusted issuers — a SAML IdP cannot shadow an OIDC or client-assertion issuer registered at the same value.
+
+### 3. Register the SP at the IdP
+
+Import the SP metadata from `/oauth/saml/{org_slug}/metadata`, or configure manually with the `sp_entity_id` (Audience) and `acs_url` (Recipient/Destination) shown in the connection.
+
+### 4. Start a login from your app
+
+```
+GET https://your-authorizer.example/oauth/saml/{org_slug}/login
+      ?redirect_uri=https://app.example.com/dashboard
+      &state=RANDOM_STATE
+```
+
+`redirect_uri` is required and validated against `--allowed-origins`. On success Authorizer sets its session cookie and redirects back to `redirect_uri` with `state` — identical app-side behavior to the [OIDC broker](./org-sso-oidc).
+
+## Attribute mapping & JIT provisioning
+
+The **NameID is always the federated subject**; federated identity is keyed by `(org_id, IdP entity ID, NameID)` — never by email, so an email collision with an existing account is rejected fail-closed rather than linked. First-time users are created and added as org members automatically.
+
+Profile attributes are extracted using the connection's `attribute_mapping` (Authorizer field → SAML attribute name). Defaults:
+
+| Authorizer field | Default SAML attribute |
+|------------------|------------------------|
+| `email` | `email` |
+| `given_name` | `firstName` |
+| `family_name` | `lastName` |
+| `nickname` | `displayName` |
+| `picture` | `picture` |
+
+## Security model
+
+Enforced at the ACS (via the vetted `crewjam/saml` library plus explicit checks):
+
+- **Signature over the consumed assertion** — the XML-DSIG is validated on the same `<Assertion>` element that is consumed (or a Response signature covering it), defeating XML Signature Wrapping (XSW). Signatures validate **only** against the org's pinned IdP certificate.
+- **Unsigned assertions are rejected.**
+- **Audience / Recipient / Destination** must match this org's SP entity ID and ACS URL — an assertion minted for Org B cannot be consumed at Org A.
+- **`NotBefore` / `NotOnOrAfter`** validated with bounded clock skew.
+- **Single-use AssertionID** — consumed assertion IDs are cached until expiry; replays are rejected.
+- **InResponseTo** — SP-initiated responses must match a pending AuthnRequest; `RelayState` is an opaque single-use handle, never trusted as a redirect URL. The final app redirect is validated against `--allowed-origins`.
+- ACS successes and failures are audited; internal errors are never echoed to the caller.
+
+### IdP-initiated SSO
+
+Disabled by default. Set `allow_idp_initiated: true` only if the org's IdP cannot do SP-initiated flows: enabling it disables InResponseTo validation for **all** responses on that connection (a library limitation), leaving replay defense solely to the single-use AssertionID cache.
+
+### AuthnRequest signing
+
+AuthnRequests are currently emitted unsigned (HTTP-Redirect binding). All SP-side assertion security is enforced at the ACS; request signing protects the IdP against forged requests and is a future upgrade.

--- a/docs/enterprise/org-sso-oidc.md
+++ b/docs/enterprise/org-sso-oidc.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 2
+title: Per-Org OIDC SSO
+---
+
+# Per-Organization OIDC SSO (Broker)
+
+Each [organization](./organizations) can bring its own upstream OIDC identity provider (Okta, Microsoft Entra ID, Google Workspace, …). Authorizer acts as the **Relying Party (broker)**: the org's users authenticate at their corporate IdP, and Authorizer JIT-provisions them and issues a normal Authorizer session — your apps keep integrating with Authorizer only.
+
+```
+User ──► /oauth/sso/{org_slug}/login ──► upstream IdP /authorize (PKCE + state + nonce)
+     ◄── /oauth/sso/{org_slug}/callback ◄── code
+Authorizer verifies ID token (JWKS, iss, aud, nonce) ──► JIT provision ──► session cookie
+     ──► redirect back to your app (redirect_uri + state)
+```
+
+## Setup
+
+### 1. Register Authorizer at the upstream IdP
+
+Create an OIDC app (authorization code flow) at the org's IdP with the redirect URI:
+
+```
+https://your-authorizer.example/oauth/sso/{org_slug}/callback
+```
+
+Note the issuer URL, client ID, and client secret the IdP gives you.
+
+### 2. Create the connection (admin API)
+
+```graphql
+mutation {
+  _create_org_oidc_connection(
+    params: {
+      org_id: "ORG_ID"
+      name: "Acme Okta"
+      issuer_url: "https://acme.okta.com" # upstream OIDC discovery base
+      client_id: "UPSTREAM_CLIENT_ID"     # issued BY the IdP TO Authorizer
+      client_secret: "UPSTREAM_SECRET"    # stored encrypted, never returned
+      # scopes: defaults to "openid profile email" when omitted
+      # redirect_uri: derived from the request host when omitted
+    }
+  ) {
+    id
+    org_id
+    issuer_url
+    sso_client_id
+    is_active
+  }
+}
+```
+
+One OIDC connection per org. Related operations:
+
+| Operation | Purpose |
+|-----------|---------|
+| `_update_org_oidc_connection` | Update fields; supplying `client_secret` rotates it, omitting leaves it intact |
+| `_delete_org_oidc_connection` | Remove the connection |
+| `_org_oidc_connection` | Fetch by connection `id` **or** by `org_id` (supply exactly one) |
+
+The upstream `client_secret` is never projected back in any response.
+
+### 3. Start a login from your app
+
+Send the org's users to:
+
+```
+GET https://your-authorizer.example/oauth/sso/{org_slug}/login
+      ?redirect_uri=https://app.example.com/dashboard
+      &state=RANDOM_STATE
+```
+
+- `redirect_uri` is **required** and must pass the instance's `--allowed-origins` validation.
+- `state` is optional and echoed back to your app.
+
+On success, Authorizer sets its session cookie and redirects the browser to your `redirect_uri` with `state` appended. From there, your app uses the normal Authorizer session (GraphQL `session` query, or silent OIDC via `/authorize`). The resulting tokens carry `login_method: "sso"`.
+
+## JIT provisioning
+
+First-time users are created automatically:
+
+- Federated identity is keyed by **`(org_id, issuer, sub)`** — never by email. An upstream assertion whose email merely collides with an existing account is **rejected fail-closed**, not linked (account-takeover defense).
+- The user is added as a member of the organization.
+- Subsequent logins match the same federated identity and reuse the account.
+
+## Security model
+
+Verified in the broker implementation:
+
+- **PKCE (S256)**, unguessable single-use `state`, and `nonce` on every upstream round trip.
+- **Mix-up defense** (RFC 9207): the returned ID token's `iss` must equal the issuer the dispatching connection discovered; an `iss` query parameter, when present, must match too.
+- ID token verified against the upstream **JWKS**; `aud` must equal the connection's upstream client ID; asymmetric algorithms only (`RS*/PS*/ES*` — `alg:none` and `HS*` are rejected).
+- All upstream fetches (discovery, JWKS, token exchange) use an SSRF-hardened HTTP client — host-pinned, redirects refused, response size capped.
+- SSO callbacks are audited (success and failure).
+
+## SAML instead?
+
+If the org's IdP only speaks SAML 2.0, use the [per-org SAML SP](./org-saml) — same org model, same JIT provisioning.

--- a/docs/enterprise/organizations.md
+++ b/docs/enterprise/organizations.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 1
+title: Organizations
+---
+
+# Organizations
+
+Organizations model tenants (customer companies, teams, business units) inside one Authorizer instance. Each organization has:
+
+- A unique, URL-safe **slug** (`name`) — it appears in per-org SSO URLs like `/oauth/sso/{org_slug}/login`.
+- An optional `display_name`.
+- An `enabled` flag — a disabled org's SSO and provisioning stop working.
+- **Members**: users linked to the org, each with a set of per-organization roles (independent of the user's global roles and of their roles in other orgs).
+
+Organizations are the anchor for the other enterprise features:
+
+| Feature | Attached per org |
+|---------|------------------|
+| [OIDC SSO broker](./org-sso-oidc) | One upstream OIDC IdP connection |
+| [SAML 2.0 SP](./org-saml) | One upstream SAML IdP connection |
+| [SCIM 2.0 provisioning](./scim) | One inbound SCIM endpoint + bearer token |
+
+Users who sign in through an org's SSO connection are JIT-provisioned and automatically added as members of that organization.
+
+## Admin API
+
+All operations are super-admin GraphQL operations (`x-authorizer-admin-secret` header or the `authorizer.admin` cookie).
+
+| Operation | Type | Purpose |
+|-----------|------|---------|
+| `_create_organization` | mutation | Create an org (`name` slug must be unique and URL-safe) |
+| `_update_organization` | mutation | Update `name`, `display_name`, `enabled` |
+| `_delete_organization` | mutation | Delete the org |
+| `_organization` | query | Fetch one org by `id` |
+| `_organizations` | query | Paginated list |
+| `_add_org_member` | mutation | Add a user as member with optional per-org roles |
+| `_remove_org_member` | mutation | Remove a member |
+| `_org_members` | query | Paginated member list for an org |
+
+### Create an organization
+
+```graphql
+mutation {
+  _create_organization(
+    params: { name: "acme", display_name: "Acme Corp" }
+  ) {
+    id
+    name
+    display_name
+    enabled
+  }
+}
+```
+
+### Manage members
+
+```graphql
+mutation {
+  _add_org_member(
+    params: {
+      org_id: "ORG_ID"
+      user_id: "USER_ID"
+      roles: ["admin"] # per-org roles; defaults to empty when omitted
+    }
+  ) {
+    id
+    org_id
+    user_id
+    roles
+  }
+}
+```
+
+```graphql
+query {
+  _org_members(params: { org_id: "ORG_ID" }) {
+    pagination { total }
+    org_members { user_id roles created_at }
+  }
+}
+```
+
+```graphql
+mutation {
+  _remove_org_member(params: { org_id: "ORG_ID", user_id: "USER_ID" }) {
+    message
+  }
+}
+```
+
+Notes:
+
+- Membership is unique per `(org_id, user_id)` — adding the same user twice is rejected.
+- Per-org roles are independent across orgs: the same user can be `admin` in one org and `viewer` in another.
+- SSO JIT provisioning and SCIM provisioning create memberships automatically; `_add_org_member` is for manual/back-office management.

--- a/docs/enterprise/scim.md
+++ b/docs/enterprise/scim.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 4
+title: SCIM 2.0 Provisioning
+---
+
+# SCIM 2.0 Provisioning
+
+Authorizer exposes a per-[organization](./organizations) inbound **SCIM 2.0** (RFC 7644) endpoint so enterprise directories (Okta, Microsoft Entra ID, OneLogin, …) can provision and deprovision that org's users automatically.
+
+- Base URL: `https://your-authorizer.example/scim/v2`
+- Authentication: `Authorization: Bearer <endpoint token>` — one token per org
+- Media type: `application/scim+json`; errors use the SCIM error schema
+
+The organization is resolved **solely from the bearer token** — never from the URL or request body — so one org's token can never touch another org's users. A missing, malformed, or wrong token is a constant-time `401`.
+
+## Create the endpoint (admin API)
+
+One SCIM endpoint per org, keyed by `org_id`:
+
+```graphql
+mutation {
+  _create_scim_endpoint(params: { org_id: "ORG_ID" }) {
+    scim_endpoint {
+      id
+      org_id
+      enabled
+    }
+    token # the bearer credential — shown ONCE, store it now
+  }
+}
+```
+
+The token is high-entropy and stored only as a hash; like client secrets, it is returned **once** at creation and once at rotation, never again.
+
+| Operation | Type | Purpose |
+|-----------|------|---------|
+| `_create_scim_endpoint` | mutation | Create the org's endpoint; returns the token once |
+| `_rotate_scim_token` | mutation | Invalidate the old token, return a new one once |
+| `_delete_scim_endpoint` | mutation | Remove the endpoint |
+| `_scim_endpoint` | query | Fetch the endpoint record (never the token) |
+
+All keyed by `org_id`.
+
+## Supported SCIM surface
+
+| Route | Method | Behavior |
+|-------|--------|----------|
+| `/scim/v2/Users` | POST | Create (JIT-provision) a user in the org |
+| `/scim/v2/Users` | GET | Only the `userName eq "..."` filter (the IdP dedup probe). An unfiltered list returns an empty set — full org enumeration is out of scope |
+| `/scim/v2/Users/{id}` | GET | Fetch one user |
+| `/scim/v2/Users/{id}` | PUT | Replace mutable profile fields + `active` flag |
+| `/scim/v2/Users/{id}` | PATCH | Partial update, including `active` transitions |
+| `/scim/v2/Users/{id}` | DELETE | Treated as deactivation (`active: false`) |
+| `/scim/v2/ServiceProviderConfig`, `/ResourceTypes`, `/Schemas` | GET | SCIM discovery documents |
+
+Groups are not yet implemented.
+
+Notes:
+
+- `userName` is required on create; if the IdP omits it, the primary email is used as `userName`.
+- `externalId` is stored and round-tripped, so the IdP can correlate its own IDs.
+
+## Deprovisioning semantics
+
+Deactivation is the enterprise-offboarding path and is **synchronous**:
+
+- `PATCH {"active": false}` (or `DELETE`) marks the user revoked and **immediately revokes their sessions and refresh tokens** — a still-held access token fails introspection and cannot be refreshed.
+- A user provisioned with `active: false` is deprovisioned from birth (no token can ever be issued).
+- `active: true` reactivates the account.
+
+## Example: provision a user
+
+```bash
+curl -s -X POST https://your-authorizer.example/scim/v2/Users \
+  -H "Authorization: Bearer $SCIM_TOKEN" \
+  -H "Content-Type: application/scim+json" \
+  -d '{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "jane@acme.com",
+    "externalId": "00u1abcd",
+    "name": { "givenName": "Jane", "familyName": "Doe" },
+    "emails": [{ "value": "jane@acme.com", "primary": true }],
+    "active": true
+  }'
+```
+
+Dedup probe (what Okta/Entra send before creating):
+
+```bash
+curl -s -G https://your-authorizer.example/scim/v2/Users \
+  -H "Authorization: Bearer $SCIM_TOKEN" \
+  --data-urlencode 'filter=userName eq "jane@acme.com"'
+```
+
+## IdP configuration pointers
+
+- **Okta** — add a SCIM 2.0 provisioning integration; set the SCIM connector base URL to `https://your-authorizer.example/scim/v2`, authentication mode *HTTP Header* with the bearer token, and enable Create/Update/Deactivate users.
+- **Microsoft Entra ID (Azure AD)** — in an enterprise application's *Provisioning* settings, set the Tenant URL to `https://your-authorizer.example/scim/v2` and the Secret Token to the endpoint token, then test the connection. Entra's deprovision flow (`PATCH active:false`) is fully supported and revokes sessions immediately.
+
+Rotate the token with `_rotate_scim_token` and update the IdP's secret whenever it may have been exposed.

--- a/docs/enterprise/token-exchange.md
+++ b/docs/enterprise/token-exchange.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 5
+title: Token Exchange & Delegation
+---
+
+# Token Exchange & Delegation (RFC 8693)
+
+Authorizer implements [RFC 8693 OAuth 2.0 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693) in a **delegation-only profile**: an agent (a `service_account` from the [client registry](../core/client-registry)) trades a user's token plus its own token for a short-lived, down-scoped, audience-bound token that carries *both* identities. Built for AI agents and service-to-service acting-on-behalf-of.
+
+Three guarantees on every downstream call:
+
+1. **Both identities travel together** — the resource server sees *agent X acting for user Y* (`sub` = user, `act.sub` = agent).
+2. **Least privilege** — the token is attenuated to the intersection of what the user has, what the agent may ever have, and what was asked for.
+3. **The chain is auditable** — `app → agent → user` is recorded in the audit log.
+
+## The `act` claim
+
+```jsonc
+{
+  "iss": "https://your-authorizer.example",
+  "sub": "user-alice-id",              // whose authority is exercised
+  "aud": "https://calendar.example",   // the bound resource (RFC 8707)
+  "scope": ["calendar:read"],          // attenuated
+  "exp": 1712500300,                   // now + 5 minutes
+  "client_id": "agent-client-id",      // RFC 9068: the calling agent
+  "act": {                             // who is acting
+    "sub": "agent-client-id",
+    "act": { "sub": "app-client-id" }  // nested: prior hop, if re-exchanged
+  }
+}
+```
+
+`sub` stays the **user**; `act.sub` is the **immediate actor** — always the *authenticated* agent's registered `client_id`, never a token-supplied claim; nested `act` encodes multi-hop delegation. The JWT header carries `typ: at+jwt` (RFC 9068). `act` and `client_id` are reserved claims — the custom access token script cannot forge them (it is not run for delegated tokens at all).
+
+## Request
+
+`POST /oauth/token` with the calling agent authenticated as a `service_account` (`client_secret_basic`, `client_secret_post`, or an RFC 7523 [`client_assertion`](./workload-identity)):
+
+| Parameter | Required | Notes |
+|-----------|----------|-------|
+| `grant_type` | Yes | `urn:ietf:params:oauth:grant-type:token-exchange` |
+| `subject_token` | Yes | The user's Authorizer access token — the authority being exercised |
+| `subject_token_type` | Yes | `urn:ietf:params:oauth:token-type:access_token` or `urn:ietf:params:oauth:token-type:jwt` |
+| `actor_token` | Yes | The agent's own access token (from `client_credentials`). Omitting it is rejected — subject-only exchange is impersonation, which this endpoint does not serve |
+| `actor_token_type` | Yes | Same URNs as `subject_token_type` |
+| `resource` | Yes | **Exactly one** (RFC 8707). Zero or repeated values are rejected — a multi-audience delegated token would be replayable across resource servers |
+| `scope` | No | Requested down-scope (space-separated) |
+
+```bash
+# 1. Agent gets its own token
+AGENT_TOKEN=$(curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -u "$AGENT_CLIENT_ID:$AGENT_CLIENT_SECRET" \
+  -d "grant_type=client_credentials" | jq -r .access_token)
+
+# 2. Exchange: user's token + agent's token → delegated token
+curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -u "$AGENT_CLIENT_ID:$AGENT_CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  -d "subject_token=$USER_ACCESS_TOKEN" \
+  -d "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  -d "actor_token=$AGENT_TOKEN" \
+  -d "actor_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  -d "resource=https://calendar.example" \
+  -d "scope=calendar:read"
+```
+
+**Response** (RFC 8693 §2.2):
+
+```json
+{
+  "access_token": "eyJhbG...",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 300,
+  "scope": "calendar:read"
+}
+```
+
+## Scope attenuation
+
+The delegated token's scope is always:
+
+```
+effective = subject_token.scope ∩ agent.allowed_scopes ( ∩ requested scope, when given )
+```
+
+- The agent's [`allowed_scopes`](../core/client-registry) is its **delegation ceiling** — it can never exceed it, even when the subject is an admin. An agent with an empty ceiling can delegate nothing (`invalid_scope`).
+- Because the subject token's own scope is always intersected, attenuation is **monotonic**: re-exchanging an already-narrowed delegated token can only narrow further — never restore scope.
+- An empty intersection is rejected with `invalid_scope`, never silently widened.
+
+## Multi-hop delegation
+
+A delegated token can itself be the `subject_token` of a further exchange (app → agent → sub-agent). The prior `act` chain nests under the new actor. The chain depth is capped at **4**; deeper chains are rejected with `invalid_request`.
+
+## Resource binding & validation
+
+- `aud` on the delegated token is the single `resource` — it is only valid at that resource server.
+- Delegated tokens are **stateless**: the downstream resource server validates them via local JWT verification against [`/.well-known/jwks.json`](../core/oauth2-oidc) (checking `iss`, `aud`, `exp`, `scope`) and/or `POST /oauth/introspect`.
+- They are **not refreshable**. TTL is fixed at **5 minutes**; the agent re-exchanges when it needs more time. The short TTL is the baseline revocation story — revoking the user stops the *next* exchange immediately (see below), and in-flight tokens die within the window.
+
+## Security invariants
+
+| Invariant | Enforcement |
+|-----------|-------------|
+| Delegation only — no impersonation | `actor_token` is mandatory; a subject-only exchange is rejected |
+| Actor is the authenticated caller | The `actor_token`'s `sub` must be the authenticated agent — a valid-but-unrelated token cannot stand in as the actor |
+| Actor identity is unforgeable | `act.sub` is stamped from the agent's registered `client_id`, never from a request or token claim |
+| Only Authorizer-issued tokens | Both tokens must verify against this server's signing key, with `iss` bound to this host and `token_type=access_token` |
+| Revoked users cannot seed delegation | A deactivated/revoked subject user (e.g. [SCIM](./scim) `active:false`) is rejected fail-closed; a user that cannot be loaded is also rejected (a DB error never fails open) |
+| Non-widening | Monotonic scope intersection (above) |
+| Bounded chains | `act` depth ≤ 4 |
+| Auditable | Every exchange logs actor, `on_behalf_of` (+ type `user`/`agent`), the serialized delegation chain (`app>agent>user`), and the bound resource in the audit log metadata |
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `invalid_request` | Missing/unsupported token types, missing `actor_token`, `resource` count ≠ 1, chain too deep |
+| `invalid_grant` | Subject or actor token invalid/expired, actor token not the caller's, subject revoked or unverifiable |
+| `invalid_scope` | Empty agent ceiling, or empty intersection after attenuation |
+| `invalid_client` / `unauthorized_client` | Client authentication failed, or the caller is not a `service_account` |

--- a/docs/enterprise/workload-identity.md
+++ b/docs/enterprise/workload-identity.md
@@ -1,0 +1,165 @@
+---
+sidebar_position: 6
+title: Workload Identity
+---
+
+# Workload Identity (Secretless Client Authentication)
+
+A [`service_account` client](../core/client-registry) normally authenticates with a stored `client_secret`. Workload identity removes the stored secret entirely: the workload authenticates at `POST /oauth/token` with a signed JWT it **already possesses** — a Kubernetes projected ServiceAccount token or a SPIFFE JWT-SVID — presented as an [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523) `client_assertion`. Nothing to distribute, rotate, or leak.
+
+The assertion works as client authentication on both machine grants: [`client_credentials`](../core/client-registry) and [token exchange](./token-exchange).
+
+```
+Workload holds a platform-issued JWT (K8s SA token / SPIFFE JWT-SVID)
+   ──► POST /oauth/token  grant_type=client_credentials
+        client_assertion_type=...jwt-bearer   client_assertion=<JWT>
+Authorizer: iss → trusted issuer row → JWKS verify → aud/exp/subject/replay checks
+   ──► authenticates AS the bound service_account ──► Authorizer access token
+```
+
+## Request
+
+No `client_id` and no `client_secret` — the client is derived from the trusted issuer the assertion's `iss` resolves to. Presenting a `client_assertion` together with any other authentication method is rejected (RFC 6749 §2.3).
+
+| Parameter | Value |
+|-----------|-------|
+| `client_assertion_type` | `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` (K8s SA tokens, cloud/generic OIDC tokens) or `urn:ietf:params:oauth:client-assertion-type:jwt-spiffe` (SPIFFE JWT-SVIDs) |
+| `client_assertion` | The external JWT itself |
+
+## Trusted issuers (admin API)
+
+An assertion is only accepted if its `iss` matches a **trusted issuer** the admin has registered and bound to a specific service account. Super-admin GraphQL operations (also on `AuthorizerAdminService` gRPC/REST):
+
+| Operation | Type | Purpose |
+|-----------|------|---------|
+| `_add_trusted_issuer` | mutation | Register an issuer for a service account |
+| `_update_trusted_issuer` | mutation | Update `name`, `jwks_url`, `expected_aud`, `allowed_subjects`, `is_active` |
+| `_delete_trusted_issuer` | mutation | Remove the issuer |
+| `_trusted_issuer` | query | Fetch one by `id` |
+| `_trusted_issuers` | query | Paginated list, optionally filtered by `service_account_id` |
+
+Fields:
+
+| Field | Notes |
+|-------|-------|
+| `service_account_id` | Internal `id` of the `service_account` client this issuer authenticates |
+| `issuer_url` | Must equal the assertion's `iss` claim exactly. Globally unique across all trusted issuers (including per-org SSO connections) |
+| `key_source_type` | `oidc_discovery` (fetch `jwks_uri` from `{issuer_url}/.well-known/openid-configuration`) or `static_jwks_url` (fetch `jwks_url` directly — required when the issuer's discovery document is not reachable) |
+| `jwks_url` | Required for `static_jwks_url` |
+| `expected_aud` | The `aud` the assertion **must** contain exactly — set it to your Authorizer URL and mint tokens with that audience, so a token minted for another service can never be replayed here |
+| `subject_claim` | Claim that identifies the workload; defaults to `sub` |
+| `allowed_subjects` | Comma-separated **exact-match** subject allow-list. **Empty = deny-all** — a row with no subjects authenticates nobody |
+| `issuer_type` | `kubernetes_sa` \| `spiffe_jwt` \| `oidc` \| `cloud_oidc` |
+
+> JWKS/discovery fetches use an SSRF-hardened HTTP client — host-pinned, redirects refused, response size capped, and private/loopback addresses rejected. The issuer's key endpoint must therefore be reachable at a publicly-routable address. The `spiffe_bundle_endpoint` key source (and its `spiffe_refresh_hint_seconds`) is accepted in the API but its fetcher is not active yet — use `oidc_discovery` or `static_jwks_url` for SPIFFE issuers today.
+
+## Validation rules
+
+Every check is fail-closed, and every rejection returns the same generic `invalid_client` so no check leaks which one failed:
+
+| Check | Rule |
+|-------|------|
+| Algorithm | Asymmetric only (`RS*`, `PS*`, `ES*`); `alg:none` and `HS*` rejected (RFC 8725) |
+| Signature | Verified against the issuer's JWKS (cached 10 minutes) |
+| Issuer | `iss` must resolve to an **active** client-assertion trust row — a per-org [SSO issuer](./org-sso-oidc) at the same URL can never authenticate an OAuth client |
+| Audience | `aud` must contain the row's `expected_aud` exactly |
+| Lifetime | `exp` and `iat` required; declared lifetime (`exp − iat`) must be ≤ 1 hour; `exp`/`nbf`/`iat` checked with 60 s clock skew |
+| Subject | `subject_claim` value must exactly match an `allowed_subjects` entry (never prefix/substring); empty list is deny-all |
+| Replay | Assertions are **single-use** — keyed by `jti`, or by `(iss, sub, iat, exp)` when `jti` is absent (K8s SA tokens carry none), held until the token's `exp` |
+| Type match | `jwt-bearer` assertions only match non-SPIFFE rows; `jwt-spiffe` only matches `spiffe_jwt` rows |
+| Bound client | Must exist, be active, and be a `service_account` |
+
+Because assertions are single-use, **mint a fresh platform token per token-endpoint call** (Kubernetes TokenRequest API, SPIFFE Workload API) rather than re-presenting a cached one.
+
+## Kubernetes ServiceAccount tokens
+
+Kubernetes clusters are OIDC issuers: projected ServiceAccount tokens are JWTs signed by the cluster, with `iss` = the cluster's issuer URL and `sub` = `system:serviceaccount:<namespace>:<name>`.
+
+### 1. Register the trusted issuer
+
+Find the cluster issuer with `kubectl get --raw /.well-known/openid-configuration | jq -r .issuer` (on managed clusters — EKS/GKE/AKS — this is a public URL and `oidc_discovery` works; for a private cluster expose the JWKS and use `static_jwks_url`):
+
+```graphql
+mutation {
+  _add_trusted_issuer(
+    params: {
+      service_account_id: "CLIENT_UUID" # the service_account client's internal id
+      name: "prod-cluster payments-worker"
+      issuer_url: "https://oidc.eks.eu-west-1.amazonaws.com/id/EXAMPLE"
+      key_source_type: "oidc_discovery"
+      expected_aud: "https://your-authorizer.example"
+      allowed_subjects: "system:serviceaccount:payments:worker"
+      issuer_type: "kubernetes_sa"
+    }
+  ) {
+    id
+    issuer_url
+    is_active
+  }
+}
+```
+
+### 2. Project a token with the right audience
+
+```yaml
+volumes:
+  - name: authorizer-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: authorizer-token
+            audience: https://your-authorizer.example # must equal expected_aud
+            expirationSeconds: 3600 # ≤ the 1-hour lifetime ceiling
+```
+
+### 3. Authenticate
+
+```bash
+JWT=$(cat /var/run/secrets/tokens/authorizer-token)
+curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
+  --data-urlencode "client_assertion=$JWT" \
+  -d "scope=read:payments"
+```
+
+For testing: `kubectl create token worker -n payments --audience=https://your-authorizer.example --duration=10m`.
+
+### Online hardening: Kubernetes TokenReview
+
+Offline JWKS validation proves the token was signed by the cluster — **not** that the bound Pod/ServiceAccount still exists. A deleted pod's not-yet-expired token would still verify. For high-security workloads a trust row can opt in to online validation (`enable_token_review` + `kubernetes_api_server_url` on the trusted-issuer record — honored at runtime but not yet exposed through the admin API): after the offline checks pass, Authorizer calls the cluster's `authentication.k8s.io/v1` TokenReview API and rejects the assertion fail-closed unless the apiserver reports it still authenticated.
+
+- Authorizer authenticates the TokenReview call with its **own** in-cluster ServiceAccount token, which needs the `system:auth-delegator` ClusterRole.
+- The apiserver URL goes through the same SSRF-hardened client, so only a **publicly-routable apiserver endpoint** (e.g. a managed cluster's public API endpoint) works today — `https://kubernetes.default.svc` (a private ClusterIP) is rejected by design.
+
+## SPIFFE JWT-SVIDs (preview)
+
+For workloads in a [SPIFFE/SPIRE](https://spiffe.io) trust domain, the JWT-SVID is the client credential (per `draft-ietf-oauth-spiffe-client-auth` — an expired individual draft, so this ships as a **preview**). Two differences from the generic path:
+
+- `client_assertion_type` is `urn:ietf:params:oauth:client-assertion-type:jwt-spiffe` and the trust row's `issuer_type` must be `spiffe_jwt` — the profiles cannot be crossed.
+- `iss` is the **SPIRE server**, and `sub` is the workload's **SPIFFE ID** (`spiffe://…`) — `iss ≠ sub` is expected. The subject must be a `spiffe://` URI and appear exactly in `allowed_subjects`.
+
+Register the issuer with `issuer_url` set to the SPIRE server's configured `jwt_issuer` and point the key source at the [SPIRE OIDC Discovery Provider](https://spiffe.io/docs/latest/keyless/) (`oidc_discovery`, or `static_jwks_url` at its keys endpoint), with `issuer_type: "spiffe_jwt"` and the workload's SPIFFE ID in `allowed_subjects`.
+
+```bash
+# Fetch a fresh JWT-SVID from the local SPIRE agent (each fetch mints a new one)
+SVID=$(spire-agent api fetch jwt \
+  -audience https://your-authorizer.example -output json | jq -r '.[0].svids[0].svid')
+
+curl -s -X POST $AUTHORIZER_URL/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-spiffe" \
+  --data-urlencode "client_assertion=$SVID" \
+  -d "scope=read:payments"
+```
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `invalid_request` | Unsupported `client_assertion_type`, or more than one client authentication method presented |
+| `invalid_client` | Any assertion validation failure (deliberately indistinguishable) |
+| `unauthorized_client` | The bound client is not a `service_account` for this grant |
+| `invalid_scope` | Requested scope outside the client's [`allowed_scopes`](../core/client-registry) |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -27,10 +27,23 @@ const sidebars: SidebarsConfig = {
         'core/grpc',
         'core/mcp',
         'core/oauth2-oidc',
+        'core/client-registry',
         'core/sso-guide',
         'core/email',
         'core/rate-limiting',
         'core/metrics-monitoring',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Enterprise',
+      items: [
+        'enterprise/organizations',
+        'enterprise/org-sso-oidc',
+        'enterprise/org-saml',
+        'enterprise/scim',
+        'enterprise/token-exchange',
+        'enterprise/workload-identity',
       ],
     },
     {


### PR DESCRIPTION
## What

Replaces #72 (auto-closed when its stacked base branch was deleted after #71 merged; same commits, now based on main).

Documents the shipped machine-agent-identity program.

**Fixes a correctness bug:** `core/sso-guide.md` listed SAML 2.0 and SCIM as "Future Roadmap" — both are shipped.

**Updated:** `core/oauth2-oidc.md` — `client_credentials` + RFC 8693 token-exchange grants in standards table, discovery metadata, token-endpoint reference.

**New pages** (every op/param verified against server source; independently re-verified in review — 15+ claims checked against `token_exchange.go`, `client_assertion.go`, `delegation_token.go`, `schema.graphqls`, `admin.proto`):
- `core/client-registry.md`
- `enterprise/organizations.md`, `org-sso-oidc.md`, `org-saml.md`, `scim.md`, `token-exchange.md`, `workload-identity.md`
- New **Enterprise** sidebar category

## Testing
- `npx docusaurus build` passes, zero broken-link warnings