### PR TITLE
docs: MFA default-on, per-method meta fields, user search by ID, org member email

### DIFF
--- a/docs/core/graphql-api.md
+++ b/docs/core/graphql-api.md
@@ -99,6 +99,10 @@ It returns `Meta` type with the following possible values
 | `is_basic_authentication_enabled` | It gives information, if basic auth is enabled or not         |
 | `is_magic_link_login_enabled`     | It gives information if password less login is enabled or not |
 | `is_sign_up_enabled`              | It gives information if sign up is enabled or not             |
+| `is_totp_mfa_enabled`             | Whether TOTP MFA enrollment and login are available           |
+| `is_email_otp_mfa_enabled`        | Whether email OTP MFA enrollment and login are available (requires SMTP configured) |
+| `is_sms_otp_mfa_enabled`          | Whether SMS OTP MFA enrollment and login are available (requires Twilio configured) |
+| `is_webauthn_enabled`             | Whether WebAuthn/passkey enrollment is available              |
 
 **Sample Query**
 
@@ -114,6 +118,10 @@ query {
     is_basic_authentication_enabled
     is_magic_link_login_enabled
     is_sign_up_enabled
+    is_totp_mfa_enabled
+    is_email_otp_mfa_enabled
+    is_sms_otp_mfa_enabled
+    is_webauthn_enabled
   }
 }
 ```
@@ -952,7 +960,13 @@ query {
 
 #### `_admin_meta`
 
-Query to get admin metadata (server info available to admins).
+Query to get admin metadata (server info available to admins). Returns all fields from `meta` plus admin-only fields.
+
+**Admin-only fields**
+
+| Key                                 | Description                                                |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `is_multi_factor_auth_service_enabled` | Whether at least one MFA method is available (at least one method enabled and its provider configured) |
 
 **Sample Query**
 
@@ -961,6 +975,10 @@ query {
   _admin_meta {
     version
     client_id
+    is_totp_mfa_enabled
+    is_email_otp_mfa_enabled
+    is_sms_otp_mfa_enabled
+    is_multi_factor_auth_service_enabled
   }
 }
 ```
@@ -979,14 +997,14 @@ Query to get all the `_users`. This query is only allowed for super admins. It r
 }
 ```
 
-It can take optional `params` input of type `PaginatedInput` with following keys
+It can take optional `params` input of type `ListUsersRequest` with following keys
 
 **Request Params**
 
-| Key     | Description                  | Required | Default |
-| ------- | ---------------------------- | -------- | ------- |
-| `page`  | Number of page that you want | false    | 1       |
-| `limit` | Number of rows that you want | false    | 10      |
+| Key          | Description                                                                           | Required | Default |
+| ------------ | ------------------------------------------------------------------------------------- | -------- | ------- |
+| `pagination` | Object with `page` and `limit` for pagination                                         | false    | page: 1, limit: 10 |
+| `query`      | Case-insensitive substring filter (matches against user ID, email, given_name, family_name, nickname). Empty or absent means no filter. | false    | empty   |
 
 **Sample Query**
 

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -431,13 +431,14 @@ Get admin-level metadata about the server (version, feature flags).
 
 #### `POST /v1/admin/users`
 
-List all users with pagination.
+List all users with pagination and optional search.
 
 **Request body**
 
 | Field        | Type                | Description  | Required |
 | ------------ | ------------------- | ------------ | -------- |
 | `pagination` | `{ page, limit }`   | Page & limit. | no       |
+| `query`      | `string`            | Case-insensitive substring filter (matches against user ID, email, given_name, family_name, nickname). | no |
 
 **Response** `{ users: User[], pagination: { page, limit, total, offset } }`
 

--- a/docs/core/server-config.md
+++ b/docs/core/server-config.md
@@ -123,14 +123,30 @@ Organization / UI:
   --enable-basic-authentication=true \
   --enable-email-verification=true \
   --enable-magic-link-login=true \
-  --enable-signup=true \
-  --enable-totp-login=true \
-  --enable-email-otp=true \
-  --enable-sms-otp=false
+  --enable-signup=true
 ```
 
 These replace v1 flags such as `DISABLE_BASIC_AUTHENTICATION`, `DISABLE_EMAIL_VERIFICATION`, etc.
 See the [Auth behavior mapping](../migration/v1-to-v2#auth-behavior) for exact correspondences.
+
+### Multi-factor authentication (MFA)
+
+```bash
+./authorizer \
+  --disable-totp-login=false \
+  --disable-email-otp=false \
+  --disable-sms-otp=false \
+  --enforce-mfa=false
+```
+
+MFA is **enabled by default** in v2. The following flags allow you to disable specific methods:
+
+- **`--disable-totp-login`** (default `false`): set to `true` to disable TOTP (time-based one-time password) MFA enrollment and login.
+- **`--disable-email-otp`** (default `false`): set to `true` to disable email OTP enrollment. Email OTP is only available when SMTP is configured (see [SMTP](#smtp)).
+- **`--disable-sms-otp`** (default `false`): set to `true` to disable SMS OTP enrollment. SMS OTP is only available when Twilio is configured (see [Twilio](#twilio-sms-otp)).
+- **`--enforce-mfa`** (default `false`): set to `true` to make MFA mandatory — all users must enroll in at least one MFA method during signup and cannot skip it. When `false`, MFA enrollment is optional.
+
+MFA is considered "available" when at least one method is enabled and its provider (SMTP for email, Twilio for SMS) is configured. The public `meta` query exposes which methods are available via `is_totp_mfa_enabled`, `is_email_otp_mfa_enabled`, and `is_sms_otp_mfa_enabled` fields, allowing the login UI to conditionally show MFA enrollment prompts.
 
 ### Cookies
 

--- a/docs/enterprise/organizations.md
+++ b/docs/enterprise/organizations.md
@@ -75,10 +75,28 @@ mutation {
 query {
   _org_members(params: { org_id: "ORG_ID" }) {
     pagination { total }
-    org_members { user_id roles created_at }
+    org_members {
+      user_id
+      roles
+      created_at
+      email
+      given_name
+      family_name
+    }
   }
 }
 ```
+
+**Organization member fields**
+
+| Field        | Type     | Description |
+| ------------ | -------- | ----------- |
+| `user_id`    | `string` | The user's unique identifier |
+| `roles`      | `[string]` | Per-organization roles assigned to this member |
+| `created_at` | `string` | Timestamp when the membership was created |
+| `email`      | `string` | User's email (may be empty if the user no longer exists) |
+| `given_name` | `string` | User's first name (may be empty if the user no longer exists) |
+| `family_name` | `string` | User's last name (may be empty if the user no longer exists) |
 
 ```graphql
 mutation {

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -272,9 +272,9 @@ Use these v2 **CLI flags** instead of v1 env or dashboard config. Flag names use
 | `DISABLE_BASIC_AUTHENTICATION`  | `--enable-basic-authentication` (inverted) |
 | `DISABLE_EMAIL_VERIFICATION`    | `--enable-email-verification` (inverted) |
 | `DISABLE_MAGIC_LINK_LOGIN`      | `--enable-magic-link-login` (inverted) |
-| `ENFORCE_MULTI_FACTOR_AUTHENTICATION` | `--enforce-mfa`, `--enable-mfa` |
+| `ENFORCE_MULTI_FACTOR_AUTHENTICATION` | `--enforce-mfa` |
 | `DISABLE_SIGN_UP`               | `--enable-signup` (inverted) |
-| TOTP / OTP                      | `--enable-totp-login`, `--enable-email-otp`, `--enable-sms-otp` |
+| TOTP / OTP (all enabled by default in v2) | `--disable-totp-login`, `--disable-email-otp`, `--disable-sms-otp` (use to opt-out) |
 | Mobile basic auth               | `--enable-mobile-basic-authentication` |
 | Phone verification              | `--enable-phone-verification` |
 
@@ -404,6 +404,21 @@ its first burst:
 
 See the new [Security Hardening](../core/security#trusted-proxies) page
 for the full topology table and flag reference.
+
+#### MFA flags reversed: `--enable-*` removed, `--disable-*` added
+
+MFA is now **enabled by default** and **optional per user** (unless `--enforce-mfa=true`). The v1 pattern of opt-in flags has been inverted:
+
+| v1 | v2 |
+|----|----|
+| `--enable-totp-login=true` | `--disable-totp-login=false` (default) |
+| `--enable-email-otp=true` | `--disable-email-otp=false` (default) |
+| `--enable-sms-otp=true` | `--disable-sms-otp=false` (default) |
+| `--enable-mfa` (no longer used) | Use `--enforce-mfa` if you need to make MFA mandatory |
+
+**Action required:** if your v1 config had `--enable-totp-login=false` or `--enable-email-otp=false`, translate them to `--disable-totp-login=true` or `--disable-email-otp=true` in v2. The old `--enable-mfa` flag is removed; do not use it.
+
+The new `--disable-totp-login`, `--disable-email-otp`, and `--disable-sms-otp` flags default to `false` (meaning the methods are enabled), and MFA is only "available" when at least one method is enabled and its provider (SMTP, Twilio) is configured.
 
 ### Database schema: `email` / `phone_number` are no longer `UNIQUE`
 


### PR DESCRIPTION
Documents the server changes merged in `authorizer` PRs #679, #680, #681, #682.

## MFA (breaking flag change)
- **`docs/core/server-config.md`** — new "Multi-factor authentication (MFA)" section: MFA is now on by default; `--disable-totp-login` / `--disable-email-otp` / `--disable-sms-otp` opt out per method; email/SMS OTP only available when SMTP/Twilio configured; `--enforce-mfa` (default `false`) makes MFA mandatory. Removed the old `--enable-*` MFA flags from the example.
- **`docs/migration/v1-to-v2.md`** — updated the auth-behavior flag mapping and added a breaking note with the `--enable-* → --disable-*` translation table.

## New meta fields
- **`docs/core/graphql-api.md`** — public `meta`: `is_totp_mfa_enabled`, `is_email_otp_mfa_enabled`, `is_sms_otp_mfa_enabled`, `is_webauthn_enabled`; admin `_admin_meta`: `is_multi_factor_auth_service_enabled`.

## Admin user search + org members
- **`graphql-api.md`** / **`rest-api.md`** — `_users` / `POST /v1/admin/users` `query` param now also matches user ID (plus email, given_name, family_name, nickname).
- **`docs/enterprise/organizations.md`** — organization member listings now expose `email` / `given_name` / `family_name` (blank if the user was deleted).

gRPC docs already defer to the GraphQL/REST field references, so no separate gRPC edits were needed.