### PR TITLE
fix(docs): correct Go SDK import path and stale type names

### DIFF
--- a/docs/core/fga-guide.md
+++ b/docs/core/fga-guide.md
@@ -162,7 +162,7 @@ Expected (Marco is `editor`):
 **Go SDK**:
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, _ := authorizer.NewAuthorizerClient("123456", "http://localhost:8080", "", nil)
 

--- a/docs/sdks/authorizer-go/admin.md
+++ b/docs/sdks/authorizer-go/admin.md
@@ -46,7 +46,7 @@ if err != nil {
     panic(err)
 }
 
-res, err := client.Login(&authorizer.LoginInput{Email: authorizer.NewStringRef("user@example.com"), Password: "Abc@123"})
+res, err := client.Login(&authorizer.LoginRequest{Email: authorizer.NewStringRef("user@example.com"), Password: "Abc@123"})
 ```
 
 > OAuth endpoints (`/oauth/token`, `/oauth/revoke`) always use REST regardless of the
@@ -77,7 +77,7 @@ for _, u := range res.Users {
 ```
 
 Request/response types for the proto-backed methods come from the generated package
-`authorizerv1 "github.com/authorizerdev/authorizer-go/internal/genpb/authorizer/v1"`.
+`authorizerv1 "github.com/authorizerdev/authorizer-proto-go/authorizer/v1"`.
 It lives under `internal/`, so Go's internal-package rule means it can only be imported by
 code whose import path is rooted at `github.com/authorizerdev/authorizer-go` — e.g. this
 module's own `examples/` tree, not an external application module. The Go-native admin

--- a/docs/sdks/authorizer-go/example.md
+++ b/docs/sdks/authorizer-go/example.md
@@ -42,7 +42,7 @@ func AuthorizeMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		res, err := authorizerClient.ValidateJWTToken(&authorizer.ValidateJWTTokenInput{
+		res, err := authorizerClient.ValidateJWTToken(&authorizer.ValidateJWTTokenRequest{
 			TokenType: authorizer.TokenTypeIDToken,
 			Token:     tokenSplit[1],
 		})

--- a/docs/sdks/authorizer-go/functions.md
+++ b/docs/sdks/authorizer-go/functions.md
@@ -8,7 +8,7 @@ title: Functions
 The `AuthorizerClient` provides methods to interact with the Authorizer API. Every method takes a request struct as a parameter and returns a response struct or an error.
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -110,7 +110,7 @@ All take a `headers` map with a bearer token (or, if the caller doesn't have one
 Get a token for a service account / machine identity created via the [admin `CreateClient`](./admin) method:
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 machine, err := authorizer.NewAuthorizerClient(
     "SERVICE_CLIENT_ID",
@@ -137,7 +137,7 @@ fmt.Println(token.AccessToken, token.Scope)
 An agent acting on behalf of a signed-in user exchanges the user's token plus its own machine token for a delegated token. The original user stays the JWT `sub`; each hop narrows `scope` and appends to the nested `act` claim (re-widening scope is rejected):
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 agent, err := authorizer.NewAuthorizerClient(
     "AGENT_CLIENT_ID",
@@ -196,7 +196,7 @@ if err != nil {
 ### Sign up
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -224,7 +224,7 @@ fmt.Println(token.Message, *token.AccessToken)
 ### Log in and read the profile
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -256,7 +256,7 @@ fmt.Println(user.ID, user.Email, user.Roles)
 ### Validate a JWT
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -280,7 +280,7 @@ fmt.Println(res.IsValid, res.Claims)
 ### Magic-link login
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -372,7 +372,7 @@ All response structs are deserializable from JSON via `json.Unmarshal()`.
 The SDK returns standard Go errors. Most API errors come back as error messages:
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 client, err := authorizer.NewAuthorizerClient(
     "YOUR_CLIENT_ID",
@@ -399,7 +399,7 @@ if err != nil {
 By default, the client uses GraphQL. You can override this with `WithProtocol`:
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 // Use REST endpoints
 client, err := authorizer.NewAuthorizerClient(
@@ -426,7 +426,7 @@ client, err = authorizer.NewAuthorizerClient(
 The SDK exports pointer constructor helpers for optional fields:
 
 ```go
-import "github.com/authorizerdev/authorizer-go"
+import "github.com/authorizerdev/authorizer-go/v2"
 
 // stringPtr(s) returns a *string pointing to s
 // intPtr(i) returns an *int64 pointing to i

--- a/docs/sdks/authorizer-go/index.md
+++ b/docs/sdks/authorizer-go/index.md
@@ -23,7 +23,7 @@ The authorizer-go SDK works with both Authorizer v1 and v2 servers. When using w
 ### Step 1: Install authorizer-go SDK
 
 ```bash
-go get github.com/authorizerdev/authorizer-go
+go get github.com/authorizerdev/authorizer-go/v2
 ```
 
 ### Step 2: Initialize authorizer client
@@ -53,7 +53,7 @@ if err != nil {
 **Example: Login**
 
 ```go
-response, err := authorizerClient.Login(&authorizer.LoginInput{
+response, err := authorizerClient.Login(&authorizer.LoginRequest{
     Email:    authorizer.NewStringRef("test@yopmail.com"),
     Password: "Abc@123",
 })
@@ -67,7 +67,7 @@ if err != nil {
 **Example: Validate JWT Token**
 
 ```go
-res, err := authorizerClient.ValidateJWTToken(&authorizer.ValidateJWTTokenInput{
+res, err := authorizerClient.ValidateJWTToken(&authorizer.ValidateJWTTokenRequest{
     TokenType: authorizer.TokenTypeIDToken,
     Token:     "your-jwt-token",
 })


### PR DESCRIPTION
## The broken part

The Go module gained the required `/v2` suffix in authorizer-go #24, but the docs still instruct:

```
go get github.com/authorizerdev/authorizer-go
import "github.com/authorizerdev/authorizer-go"
```

This is worse than a hard error — it **succeeds**, resolving to a pseudo-version from before the rename:

```
github.com/authorizerdev/authorizer-go v0.0.0-20260723093347-51768c568d86   # un-suffixed
github.com/authorizerdev/authorizer-go/v2 v2.2.0-rc.4                       # actual latest
```

So readers silently get a months-old snapshot missing every release since 23 July.

## Also fixed

- `authorizerv1` was documented as `authorizer-go/internal/genpb/authorizer/v1` — a path that no longer exists, and which was never importable anyway because it sat under `internal/`. The real path is `authorizer-proto-go/authorizer/v1`.
- Examples used the deprecated `*Input` aliases (`LoginInput`, `ValidateJWTTokenInput`, …). They still compile via type aliases, but the docs shouldn't teach the deprecated spelling. `PermissionCheckInput` and `FgaTupleInput` are deliberately left as-is — those are real types, not aliases.

## Verification

The corrected snippets were compiled and run against the published `authorizer-go/v2` and `authorizer-proto-go` modules. Docs build clean.