### PR TITLE
docs: add --encryption-key to every server config example

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,6 +54,7 @@ Please ask as many questions as you need, either directly in the issue or on [Di
      --database-url=test.db \
      --jwt-type=HS256 \
      --jwt-secret=test \
+     --encryption-key="$(openssl rand -hex 32)" \
      --admin-secret=admin \
      --client-id=123456 \
      --client-secret=secret

--- a/docs/core/databases.md
+++ b/docs/core/databases.md
@@ -140,6 +140,7 @@ Example with Redis:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret \

--- a/docs/core/fga-guide.md
+++ b/docs/core/fga-guide.md
@@ -29,6 +29,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -52,7 +52,8 @@ Before any client can use Authorizer for SSO, you need to tell the server which 
   --allowed-origins=https://app.example.com,http://localhost:3000 \
   --jwt-type=RS256 \
   --jwt-private-key="$(cat /etc/authorizer/jwt-private.pem)" \
-  --jwt-public-key="$(cat /etc/authorizer/jwt-public.pem)"
+  --jwt-public-key="$(cat /etc/authorizer/jwt-public.pem)" \
+  --encryption-key="$(openssl rand -hex 32)"
 ```
 
 For production, use RSA or ECDSA keys (not HMAC) so public clients can verify tokens via the JWKS endpoint without sharing the signing secret. See the [Server Configuration guide](./server-config) for all flags.

--- a/docs/core/sso-guide.md
+++ b/docs/core/sso-guide.md
@@ -68,6 +68,7 @@ authorizer serve \
 Key flags for SSO:
 - `--allowed-origins` — Whitelist all app domains that will redirect to Authorizer for login.
 - `--jwt-type` and `--jwt-secret` / `--jwt-private-key` — Configure token signing (RS256 recommended for multi-app setups since apps verify with the public key via JWKS).
+- `--encryption-key` — Encrypts TOTP secrets and OTP digests at rest. **Required with `RS*`/`ES*`** (2.4.0+): there is no `--jwt-secret` to fall back to, so the server refuses to start without it.
 
 ### 2. Note Your Client Credentials
 

--- a/docs/deployment/alibaba-cloud.md
+++ b/docs/deployment/alibaba-cloud.md
@@ -31,6 +31,7 @@ After deployment, configure the required v2 variables in your instance:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/deployment/binary.md
+++ b/docs/deployment/binary.md
@@ -87,7 +87,8 @@ ExecStart=/path_to_authorizer_parent_folder/authorizer/build/authorizer \
   --admin-secret=${ADMIN_SECRET} \
   --jwt-type=RS256 \
   --jwt-private-key=${JWT_PRIVATE_KEY} \
-  --jwt-public-key=${JWT_PUBLIC_KEY}
+  --jwt-public-key=${JWT_PUBLIC_KEY} \
+  --encryption-key=${ENCRYPTION_KEY}
 WorkingDirectory=/path_to_authorizer_parent_folder/authorizer/
 Environment=DATABASE_URL=postgres://user:pass@host/db
 Environment=CLIENT_ID=your-client-id
@@ -95,6 +96,7 @@ Environment=CLIENT_SECRET=your-client-secret
 Environment=ADMIN_SECRET=your-admin-secret
 Environment=JWT_PRIVATE_KEY=...
 Environment=JWT_PUBLIC_KEY=...
+Environment=ENCRYPTION_KEY=generate-with-openssl-rand-hex-32
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -17,6 +17,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -55,6 +56,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=your-jwt-secret \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=your-admin-secret \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/deployment/easypanel.md
+++ b/docs/deployment/easypanel.md
@@ -27,6 +27,7 @@ After deployment, update the start command to include the required v2 CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -38,6 +39,7 @@ After deployment, update the start command to include the required v2 CLI flags:
 | `--database-url` | `test.db` |
 | `--jwt-type` | `HS256` |
 | `--jwt-secret` | `test` |
+| `--encryption-key` | *(output of `openssl rand -hex 32`)* |
 | `--admin-secret` | `admin` |
 | `--client-id` | `123456` |
 | `--client-secret` | `secret` |

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -72,6 +72,7 @@ cmd = [
   "--database-url=postgres://user:pass@localhost:5432/authorizer",
   "--jwt-type=HS256",
   "--jwt-secret=test",
+  "--encryption-key=$ENCRYPTION_KEY",
   "--admin-secret=admin",
   "--client-id=123456",
   "--client-secret=secret"
@@ -115,6 +116,7 @@ flyctl secrets set \
     DATABASE_TYPE="postgres" \
     JWT_TYPE="HS256" \
     JWT_SECRET="your-jwt-secret" \
+    ENCRYPTION_KEY="$(openssl rand -hex 32)" \
     ADMIN_SECRET="your-admin-secret" \
     CLIENT_ID="123456" \
     CLIENT_SECRET="secret" \

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -59,6 +59,7 @@ helm install \
     --set authorizer.database_url="postgres://user:pass@host:5432/authorizer" \
     --set authorizer.jwt_type=HS256 \
     --set authorizer.jwt_secret=your-jwt-secret \
+    --set authorizer.encryption_key="$(openssl rand -hex 32)" \
     --set authorizer.admin_secret=your-admin-secret \
     --set authorizer.client_id=123456 \
     --set authorizer.client_secret=secret \
@@ -155,6 +156,7 @@ containers:
       - "--database-url=$(DATABASE_URL)"
       - "--jwt-type=HS256"
       - "--jwt-secret=$(JWT_SECRET)"
+      - "--encryption-key=$(ENCRYPTION_KEY)"
       - "--admin-secret=$(ADMIN_SECRET)"
       - "--client-id=$(CLIENT_ID)"
       - "--client-secret=$(CLIENT_SECRET)"

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -31,6 +31,7 @@ For Authorizer v2, configure the following required variables in your Heroku app
 | `DATABASE_URL` | *(auto-configured by Heroku add-on)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
+| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |
@@ -52,7 +53,7 @@ Use `REDIS_URL` for shared sessions and rate limits across dynos ([rate limiting
 Update the Procfile or startup command to pass CLI flags:
 
 ```
-web: ./authorizer --database-type=$DATABASE_TYPE --database-url=$DATABASE_URL --jwt-type=$JWT_TYPE --jwt-secret=$JWT_SECRET --admin-secret=$ADMIN_SECRET --client-id=$CLIENT_ID --client-secret=$CLIENT_SECRET
+web: ./authorizer --database-type=$DATABASE_TYPE --database-url=$DATABASE_URL --jwt-type=$JWT_TYPE --jwt-secret=$JWT_SECRET --encryption-key=$ENCRYPTION_KEY --admin-secret=$ADMIN_SECRET --client-id=$CLIENT_ID --client-secret=$CLIENT_SECRET
 ```
 
 ---

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -15,6 +15,17 @@ Key differences from v1:
 
 ## Required Variables
 
+:::info `--encryption-key` (2.4.0+)
+
+Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-type`
+is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
+start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
+distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest
+data and locks out every enrolled TOTP user. Omit the flag on releases before
+2.4.0, which do not have it. See [Server Configuration](/core/server-config).
+
+:::
+
 All deployments require these flags with sample values:
 
 ```bash
@@ -22,6 +33,7 @@ All deployments require these flags with sample values:
 --database-url=test.db \
 --jwt-type=HS256 \
 --jwt-secret=test \
+--encryption-key="$(openssl rand -hex 32)" \
 --admin-secret=admin \
 --client-id=123456 \
 --client-secret=secret

--- a/docs/deployment/koyeb.md
+++ b/docs/deployment/koyeb.md
@@ -45,6 +45,7 @@ Add the following environment variables:
 | `DATABASE_URL` | `postgres://user:pass@host:5432/db` |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
+| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |
@@ -57,6 +58,7 @@ Update the start command to pass CLI flags:
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \
   --jwt-secret=$JWT_SECRET \
+  --encryption-key=$ENCRYPTION_KEY \
   --admin-secret=$ADMIN_SECRET \
   --client-id=$CLIENT_ID \
   --client-secret=$CLIENT_SECRET

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -93,6 +93,7 @@ spec:
             - "--client-secret=$(CLIENT_SECRET)"
             - "--admin-secret=$(ADMIN_SECRET)"
             - "--jwt-type=RS256"
+            - "--encryption-key=$(ENCRYPTION_KEY)"
             # Example: mount keys from files or use env and expand here
             - "--enable-login-page=true"
             - "--enable-playground=false"

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -33,6 +33,7 @@ After deployment, configure the following required variables in Railway's enviro
 | `DATABASE_URL` | *(auto-configured by Railway)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
+| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |
@@ -59,6 +60,7 @@ Update the start command to pass CLI flags:
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \
   --jwt-secret=$JWT_SECRET \
+  --encryption-key=$ENCRYPTION_KEY \
   --admin-secret=$ADMIN_SECRET \
   --client-id=$CLIENT_ID \
   --client-secret=$CLIENT_SECRET

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -37,6 +37,7 @@ Set the following required environment variables:
 | `DATABASE_URL` | *(auto-configured by Render)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
+| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |
@@ -63,6 +64,7 @@ Update the start command to pass CLI flags:
   --database-url=$DATABASE_URL \
   --jwt-type=$JWT_TYPE \
   --jwt-secret=$JWT_SECRET \
+  --encryption-key=$ENCRYPTION_KEY \
   --admin-secret=$ADMIN_SECRET \
   --client-id=$CLIENT_ID \
   --client-secret=$CLIENT_SECRET

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -14,12 +14,24 @@ If you are upgrading from v1, read the [Migration v1 to v2](../migration/v1-to-v
 
 All examples below use these required variables. Replace with your own values for production:
 
+:::info `--encryption-key` (2.4.0+)
+
+Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-type`
+is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
+start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
+distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest
+data and locks out every enrolled TOTP user. Omit the flag on releases before
+2.4.0, which do not have it. See [Server Configuration](/core/server-config).
+
+:::
+
 | Flag | Description | Sample Value |
 | ---- | ----------- | ------------ |
 | `--database-type` | Database type | `sqlite` |
 | `--database-url` | Database connection string | `test.db` |
 | `--jwt-type` | JWT signing algorithm | `HS256` |
 | `--jwt-secret` | JWT signing secret | `test` |
+| `--encryption-key` | At-rest key for TOTP secrets and OTP digests (2.4.0+). Required with `RS*`/`ES*` | `openssl rand -hex 32` |
 | `--admin-secret` | Admin secret for admin operations | `admin` |
 | `--client-id` | Client identifier **(required)** | `123456` |
 | `--client-secret` | Client secret **(required)** | `secret` |
@@ -49,6 +61,7 @@ go build -o build/authorizer .
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -64,6 +77,7 @@ go run main.go \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -79,6 +93,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -92,6 +107,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -116,6 +132,7 @@ cd authorizer
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -174,6 +191,7 @@ For a quick local dev setup:
   --admin-secret=admin \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --allowed-origins=http://localhost:3000
 ```
 

--- a/docs/integrations/gatsbyjs.md
+++ b/docs/integrations/gatsbyjs.md
@@ -27,6 +27,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/integrations/hasura.md
+++ b/docs/integrations/hasura.md
@@ -28,7 +28,7 @@ You can also deploy Authorizer instance using
 
 > **Note:** If you are trying out with one click deployment options like railway then template is configured in a way that it will also deploy postgres + redis for you. For other deployment options, start the server with the required CLI flags:
 > ```bash
-> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --admin-secret=admin --client-id=123456 --client-secret=secret
+> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --encryption-key="$(openssl rand -hex 32)" --admin-secret=admin --client-id=123456 --client-secret=secret
 > ```
 > You can also configure `--redis-url` to have persisted sessions. For more information check [Server Configuration](/core/server-config).
 
@@ -44,6 +44,7 @@ Configure your Authorizer instance using CLI flags at startup. In v2, all config
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret \

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -32,6 +32,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -52,6 +52,7 @@ Authorizer v2 focuses on simpler, more secure configuration and a cleaner operat
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -65,6 +66,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -74,6 +74,7 @@ In **v2**:
    - `--client-id` and `--client-secret` — **required**; the server will exit if they are missing.
    - `--admin-secret` — needed for admin dashboard access and admin API operations.
    - `--jwt-type` and `--jwt-secret` (for HMAC algorithms like HS256) or `--jwt-private-key` / `--jwt-public-key` (for RSA/ECDSA algorithms) — needed for token signing and verification.
+   - `--encryption-key` — encrypts TOTP secrets and OTP digests at rest (2.4.0+). **Required for RSA/ECDSA deployments**, which have no `--jwt-secret` to fall back to; the server refuses to start without it. HMAC deployments fall back to `--jwt-secret` automatically.
 
 ---
 
@@ -292,6 +293,7 @@ Use these v2 **CLI flags** instead of v1 env or dashboard config. Flag names use
 | `JWT_SECRET`               | `--jwt-secret` |
 | `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` | `--jwt-private-key`, `--jwt-public-key` |
 | `JWT_ROLE_CLAIM`           | `--jwt-role-claim` |
+| *(new in 2.4.0)*           | `--encryption-key` |
 | `CUSTOM_ACCESS_TOKEN_SCRIPT` | `--custom-access-token-script` |
 
 ### SMTP

--- a/docs/sdks/authorizer-js/index.md
+++ b/docs/sdks/authorizer-js/index.md
@@ -36,6 +36,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-python/index.md
+++ b/docs/sdks/authorizer-python/index.md
@@ -38,6 +38,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-react/index.md
+++ b/docs/sdks/authorizer-react/index.md
@@ -31,6 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-svelte/index.md
+++ b/docs/sdks/authorizer-svelte/index.md
@@ -31,6 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-vue/index.md
+++ b/docs/sdks/authorizer-vue/index.md
@@ -31,6 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
+  --encryption-key="$(openssl rand -hex 32)" \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret


### PR DESCRIPTION
Follow-up to the 2.4.0 at-rest key change. `docs/core/server-config.md` and `docs/core/security.md` already described it; every other page still showed configs that will not boot.

## Why

Verified against a binary built from `authorizer@main`:

- `RS256`, no `--encryption-key` → `Error: --encryption-key is required: no encryption key is set and --jwt-secret is empty (normal for RSA/ECDSA JWT types)...` — process exits
- `RS256` with `--encryption-key` → boots
- `HS256`, no `--encryption-key` → boots, falls back to `--jwt-secret`

So asymmetric examples were broken-on-upgrade, and HMAC examples were merely risky (rotating `--jwt-secret` silently re-keys TOTP secrets and locks out every enrolled user).

## Changes

28 files. Asymmetric examples — `core/oauth2-oidc.md`, `core/sso-guide.md`, `deployment/binary.md`, `deployment/kubernetes.md`, `migration/v1-to-v2.md` — now pass the flag. HMAC examples across getting-started, deployment, integrations and SDK pages set a distinct key via `openssl rand -hex 32`. Platform pages that configure env vars (Heroku, Render, Railway, Koyeb, Fly.io) gained an `ENCRYPTION_KEY` row and expand it in the start command. Flag tables gained a row, and `getting-started` / `deployment/index` gained a short admonition covering the RS*/ES* requirement, the HMAC fallback, and the fact that pre-2.4.0 builds do not have the flag.

`npm run build` passes.

Sample values are `openssl rand -hex 32` rather than a literal like `test` — this key protects TOTP seeds and password-reset OTP digests, so a copy-pasted weak value has real consequences.