### PR TITLE
docs: use a stable sample encryption key, not inline generation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,7 +54,7 @@ Please ask as many questions as you need, either directly in the issue or on [Di
      --database-url=test.db \
      --jwt-type=HS256 \
      --jwt-secret=test \
-     --encryption-key="$(openssl rand -hex 32)" \
+     --encryption-key=test-encryption-key \
      --admin-secret=admin \
      --client-id=123456 \
      --client-secret=secret

--- a/docs/core/databases.md
+++ b/docs/core/databases.md
@@ -140,7 +140,7 @@ Example with Redis:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret \

--- a/docs/core/fga-guide.md
+++ b/docs/core/fga-guide.md
@@ -29,7 +29,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/core/mcp.md
+++ b/docs/core/mcp.md
@@ -63,6 +63,7 @@ authorizer mcp \
   --client-id=YOUR_CLIENT_ID \
   --database-type=sqlite \
   --database-url=auth.db \
+  --encryption-key=your-encryption-key \
   --mcp-bearer="$USER_ACCESS_TOKEN" \
   --mcp-authorizer-url=https://auth.example.com
 ```
@@ -103,6 +104,7 @@ Most MCP hosts read a JSON config that declares the command to spawn. For
         "--client-id", "YOUR_CLIENT_ID",
         "--database-type", "sqlite",
         "--database-url", "auth.db",
+        "--encryption-key", "your-encryption-key",
         "--mcp-bearer", "USER_ACCESS_TOKEN",
         "--mcp-authorizer-url", "https://auth.example.com"
       ]

--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -53,7 +53,7 @@ Before any client can use Authorizer for SSO, you need to tell the server which 
   --jwt-type=RS256 \
   --jwt-private-key="$(cat /etc/authorizer/jwt-private.pem)" \
   --jwt-public-key="$(cat /etc/authorizer/jwt-public.pem)" \
-  --encryption-key="$(openssl rand -hex 32)"
+  --encryption-key=your-encryption-key
 ```
 
 For production, use RSA or ECDSA keys (not HMAC) so public clients can verify tokens via the JWKS endpoint without sharing the signing secret. See the [Server Configuration guide](./server-config) for all flags.

--- a/docs/core/rate-limiting.md
+++ b/docs/core/rate-limiting.md
@@ -142,6 +142,7 @@ services:
     command:
       - --database-type=postgres
       - --database-url=postgres://user:pass@db:5432/authorizer
+      - --encryption-key=your-encryption-key
       - --redis-url=redis://redis:6379
       - --rate-limit-rps=30
       - --rate-limit-burst=20

--- a/docs/core/server-config.md
+++ b/docs/core/server-config.md
@@ -211,7 +211,8 @@ Or for asymmetric keys:
 ./authorizer \
   --jwt-type=RS256 \
   --jwt-private-key="$(cat /path/to/private.key)" \
-  --jwt-public-key="$(cat /path/to/public.key)"
+  --jwt-public-key="$(cat /path/to/public.key)" \
+  --encryption-key=your-encryption-key
 ```
 
 Additional flags:

--- a/docs/core/sso-guide.md
+++ b/docs/core/sso-guide.md
@@ -62,7 +62,8 @@ authorizer serve \
   --smtp-port 587 \
   --smtp-username "auth@yourcompany.com" \
   --smtp-password "..." \
-  --sender-email "auth@yourcompany.com"
+  --sender-email "auth@yourcompany.com" \
+  --encryption-key your-encryption-key
 ```
 
 Key flags for SSO:

--- a/docs/deployment/alibaba-cloud.md
+++ b/docs/deployment/alibaba-cloud.md
@@ -31,7 +31,7 @@ After deployment, configure the required v2 variables in your instance:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/deployment/binary.md
+++ b/docs/deployment/binary.md
@@ -54,7 +54,8 @@ Example for SQLite:
   --client-secret=YOUR_CLIENT_SECRET \
   --admin-secret=your-admin-secret \
   --jwt-type=HS256 \
-  --jwt-secret=your-jwt-secret
+  --jwt-secret=your-jwt-secret \
+  --encryption-key=your-encryption-key
 ```
 
 > **Note:** In v2, flags such as `database_url`, `env_file`, and dashboard mutations like `_update_env` are **deprecated** -- use the `kebab-case` flags above instead.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -17,7 +17,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -56,7 +56,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=your-jwt-secret \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=your-admin-secret \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -80,6 +80,7 @@ services:
       - "--database-url=/data/test.db"
       - "--jwt-type=HS256"
       - "--jwt-secret=test"
+      - "--encryption-key=test-encryption-key"
       - "--admin-secret=admin"
       - "--client-id=123456"
       - "--client-secret=secret"
@@ -130,6 +131,7 @@ services:
       - "--redis-url=redis://redis:6379"
       - "--jwt-type=HS256"
       - "--jwt-secret=test"
+      - "--encryption-key=test-encryption-key"
       - "--admin-secret=admin"
       - "--client-id=123456"
       - "--client-secret=secret"
@@ -150,6 +152,7 @@ docker run -p 8080:8080 \
   -e DATABASE_TYPE=sqlite \
   -e DATABASE_URL=test.db \
   -e JWT_SECRET=test \
+  -e ENCRYPTION_KEY=test-encryption-key \
   -e ADMIN_SECRET=admin \
   -e CLIENT_ID=123456 \
   -e CLIENT_SECRET=secret \
@@ -158,6 +161,7 @@ docker run -p 8080:8080 \
     --database-url="$DATABASE_URL" \
     --jwt-type=HS256 \
     --jwt-secret="$JWT_SECRET" \
+    --encryption-key="$ENCRYPTION_KEY" \
     --admin-secret="$ADMIN_SECRET" \
     --client-id="$CLIENT_ID" \
     --client-secret="$CLIENT_SECRET"

--- a/docs/deployment/easypanel.md
+++ b/docs/deployment/easypanel.md
@@ -27,7 +27,7 @@ After deployment, update the start command to include the required v2 CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -39,7 +39,7 @@ After deployment, update the start command to include the required v2 CLI flags:
 | `--database-url` | `test.db` |
 | `--jwt-type` | `HS256` |
 | `--jwt-secret` | `test` |
-| `--encryption-key` | *(output of `openssl rand -hex 32`)* |
+| `--encryption-key` | *(generate once with `openssl rand -hex 32`)* |
 | `--admin-secret` | `admin` |
 | `--client-id` | `123456` |
 | `--client-secret` | `secret` |

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -116,7 +116,7 @@ flyctl secrets set \
     DATABASE_TYPE="postgres" \
     JWT_TYPE="HS256" \
     JWT_SECRET="your-jwt-secret" \
-    ENCRYPTION_KEY="$(openssl rand -hex 32)" \
+    ENCRYPTION_KEY="your-encryption-key" \
     ADMIN_SECRET="your-admin-secret" \
     CLIENT_ID="123456" \
     CLIENT_SECRET="secret" \

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -42,6 +42,7 @@ helm install \
     --set authorizer.database_url="/tmp/test.db" \
     --set authorizer.jwt_type=HS256 \
     --set authorizer.jwt_secret=test \
+    --set authorizer.encryption_key=test-encryption-key \
     --set authorizer.admin_secret=admin \
     --set authorizer.client_id=123456 \
     --set authorizer.client_secret=secret \

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -59,7 +59,7 @@ helm install \
     --set authorizer.database_url="postgres://user:pass@host:5432/authorizer" \
     --set authorizer.jwt_type=HS256 \
     --set authorizer.jwt_secret=your-jwt-secret \
-    --set authorizer.encryption_key="$(openssl rand -hex 32)" \
+    --set authorizer.encryption_key=your-encryption-key \
     --set authorizer.admin_secret=your-admin-secret \
     --set authorizer.client_id=123456 \
     --set authorizer.client_secret=secret \

--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -31,7 +31,7 @@ For Authorizer v2, configure the following required variables in your Heroku app
 | `DATABASE_URL` | *(auto-configured by Heroku add-on)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
-| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
+| `ENCRYPTION_KEY` | *(generate once with `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -21,7 +21,11 @@ Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-typ
 is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
 start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
 distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest
-data and locks out every enrolled TOTP user. Omit the flag on releases before
+data and locks out every enrolled TOTP user.
+
+Generate it **once** (`openssl rand -hex 32`), store it as a secret, and keep it
+stable across restarts — a key that changes on every boot leaves existing TOTP
+enrolments and pending OTPs undecryptable. Omit the flag on releases before
 2.4.0, which do not have it. See [Server Configuration](/core/server-config).
 
 :::
@@ -33,7 +37,7 @@ All deployments require these flags with sample values:
 --database-url=test.db \
 --jwt-type=HS256 \
 --jwt-secret=test \
---encryption-key="$(openssl rand -hex 32)" \
+--encryption-key=test-encryption-key \
 --admin-secret=admin \
 --client-id=123456 \
 --client-secret=secret

--- a/docs/deployment/koyeb.md
+++ b/docs/deployment/koyeb.md
@@ -45,7 +45,7 @@ Add the following environment variables:
 | `DATABASE_URL` | `postgres://user:pass@host:5432/db` |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
-| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
+| `ENCRYPTION_KEY` | *(generate once with `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -33,7 +33,7 @@ After deployment, configure the following required variables in Railway's enviro
 | `DATABASE_URL` | *(auto-configured by Railway)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
-| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
+| `ENCRYPTION_KEY` | *(generate once with `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -37,7 +37,7 @@ Set the following required environment variables:
 | `DATABASE_URL` | *(auto-configured by Render)* |
 | `JWT_TYPE` | `HS256` |
 | `JWT_SECRET` | `test` |
-| `ENCRYPTION_KEY` | *(output of `openssl rand -hex 32`)* |
+| `ENCRYPTION_KEY` | *(generate once with `openssl rand -hex 32`)* |
 | `ADMIN_SECRET` | `admin` |
 | `CLIENT_ID` | `123456` |
 | `CLIENT_SECRET` | `secret` |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -20,7 +20,11 @@ Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-typ
 is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
 start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
 distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest
-data and locks out every enrolled TOTP user. Omit the flag on releases before
+data and locks out every enrolled TOTP user.
+
+Generate it **once** (`openssl rand -hex 32`), store it as a secret, and keep it
+stable across restarts — a key that changes on every boot leaves existing TOTP
+enrolments and pending OTPs undecryptable. Omit the flag on releases before
 2.4.0, which do not have it. See [Server Configuration](/core/server-config).
 
 :::
@@ -31,7 +35,7 @@ data and locks out every enrolled TOTP user. Omit the flag on releases before
 | `--database-url` | Database connection string | `test.db` |
 | `--jwt-type` | JWT signing algorithm | `HS256` |
 | `--jwt-secret` | JWT signing secret | `test` |
-| `--encryption-key` | At-rest key for TOTP secrets and OTP digests (2.4.0+). Required with `RS*`/`ES*` | `openssl rand -hex 32` |
+| `--encryption-key` | At-rest key for TOTP secrets and OTP digests (2.4.0+). Required with `RS*`/`ES*` | *(generate once with `openssl rand -hex 32`)* |
 | `--admin-secret` | Admin secret for admin operations | `admin` |
 | `--client-id` | Client identifier **(required)** | `123456` |
 | `--client-secret` | Client secret **(required)** | `secret` |
@@ -61,7 +65,7 @@ go build -o build/authorizer .
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -77,7 +81,7 @@ go run main.go \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -93,7 +97,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -107,7 +111,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -132,7 +136,7 @@ cd authorizer
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -191,7 +195,7 @@ For a quick local dev setup:
   --admin-secret=admin \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --allowed-origins=http://localhost:3000
 ```
 

--- a/docs/integrations/gatsbyjs.md
+++ b/docs/integrations/gatsbyjs.md
@@ -27,7 +27,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/integrations/hasura.md
+++ b/docs/integrations/hasura.md
@@ -28,7 +28,7 @@ You can also deploy Authorizer instance using
 
 > **Note:** If you are trying out with one click deployment options like railway then template is configured in a way that it will also deploy postgres + redis for you. For other deployment options, start the server with the required CLI flags:
 > ```bash
-> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --encryption-key="$(openssl rand -hex 32)" --admin-secret=admin --client-id=123456 --client-secret=secret
+> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --encryption-key=test-encryption-key --admin-secret=admin --client-id=123456 --client-secret=secret
 > ```
 > You can also configure `--redis-url` to have persisted sessions. For more information check [Server Configuration](/core/server-config).
 
@@ -44,7 +44,7 @@ Configure your Authorizer instance using CLI flags at startup. In v2, all config
   --database-url="postgres://user:pass@host:5432/authorizer" \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret \

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -32,7 +32,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -52,7 +52,7 @@ Authorizer v2 focuses on simpler, more secure configuration and a cleaner operat
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret
@@ -66,7 +66,7 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -105,7 +105,8 @@ Pass all config as **CLI arguments** when starting the server:
   --client-secret=YOUR_CLIENT_SECRET \
   --admin-secret=your-admin-secret \
   --jwt-type=HS256 \
-  --jwt-secret=your-jwt-secret
+  --jwt-secret=your-jwt-secret \
+  --encryption-key=your-encryption-key
 ```
 
 For local development (from repo root):
@@ -114,7 +115,7 @@ For local development (from repo root):
 make dev
 # or
 go run main.go --database-type=sqlite --database-url=test.db \
-  --jwt-type=HS256 --jwt-secret=test --admin-secret=admin \
+  --jwt-type=HS256 --jwt-secret=test --encryption-key=test-encryption-key --admin-secret=admin \
   --client-id=123456 --client-secret=secret
 ```
 
@@ -131,6 +132,7 @@ To keep using env vars in your deployment:
     --database-url="$DATABASE_URL" \
     --client-id="$CLIENT_ID" \
     --client-secret="$CLIENT_SECRET" \
+    --encryption-key="$ENCRYPTION_KEY" \
     ...
   ```
 
@@ -144,13 +146,15 @@ docker run -p 8080:8080 \
   -e DATABASE_URL="postgres://..." \
   -e CLIENT_ID=... \
   -e CLIENT_SECRET=... \
+  -e ENCRYPTION_KEY=your-encryption-key \
   your-authorizer-image \
   ./authorizer \
     --database-type="$DATABASE_TYPE" \
     --database-url="$DATABASE_URL" \
     --client-id="$CLIENT_ID" \
     --client-secret="$CLIENT_SECRET" \
-    --admin-secret="$ADMIN_SECRET"
+    --admin-secret="$ADMIN_SECRET" \
+    --encryption-key="$ENCRYPTION_KEY"
 ```
 
 ### Build from source (v2)
@@ -551,7 +555,8 @@ docker run -p 8080:8080 your-image \
   --database-url="postgres://user:pass@host/db" \
   --client-id=... \
   --client-secret=... \
-  --admin-secret=...
+  --admin-secret=... \
+  --encryption-key=your-encryption-key
 ```
 
 Or use a script inside the image that maps env to flags and then runs `./authorizer ...`.

--- a/docs/sdks/authorizer-js/index.md
+++ b/docs/sdks/authorizer-js/index.md
@@ -36,7 +36,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-python/index.md
+++ b/docs/sdks/authorizer-python/index.md
@@ -38,7 +38,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-react/index.md
+++ b/docs/sdks/authorizer-react/index.md
@@ -31,7 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-svelte/index.md
+++ b/docs/sdks/authorizer-svelte/index.md
@@ -31,7 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret

--- a/docs/sdks/authorizer-vue/index.md
+++ b/docs/sdks/authorizer-vue/index.md
@@ -31,7 +31,7 @@ Start your Authorizer instance with the required CLI flags:
   --database-url=test.db \
   --jwt-type=HS256 \
   --jwt-secret=test \
-  --encryption-key="$(openssl rand -hex 32)" \
+  --encryption-key=test-encryption-key \
   --admin-secret=admin \
   --client-id=123456 \
   --client-secret=secret


### PR DESCRIPTION
Fixes a bug I introduced in #81.

Those examples read:

```bash
--encryption-key="$(openssl rand -hex 32)" \
```

Inside a start command that substitutes on **every** boot, so each restart runs with a different at-rest key. Anything written under the old key — TOTP shared secrets, pending email/SMS OTPs, password-reset digests — stops decrypting. The server starts normally, so the breakage only shows up when a user tries to use their authenticator.

Examples now use a fixed placeholder (`test-encryption-key` / `your-encryption-key`, matching each example's existing `--jwt-secret` style). `openssl rand -hex 32` stays where it belongs — the flag tables and the callout, as a generate-**once** instruction — and the callout now says explicitly to store it and keep it stable across restarts.

24 files. `npm run build` passes.