### PR TITLE
docs: link standards on first mention, fix stale refs

### DIFF
--- a/docs/core/authorization.md
+++ b/docs/core/authorization.md
@@ -35,7 +35,7 @@ The engine stores its model and tuples in a SQL datastore.
 
 - **SQL main database** (SQLite, Postgres, MySQL, …): FGA is **enabled by default** and
   reuses your main database. Nothing to configure.
-- **NoSQL main database** (MongoDB, DynamoDB, …): OpenFGA can't use these, so FGA is
+- **NoSQL main database** (MongoDB, DynamoDB, …): [OpenFGA](https://openfga.dev) can't use these, so FGA is
   **disabled** unless you point it at a SQL store with `--fga-store`.
 
 | Flag | Purpose |
@@ -166,7 +166,7 @@ A **machine caller** (a `client_credentials` token from a `service_account` clie
 has its own subject too: it resolves to `service_account:<client_id>`, not
 `user:<sub>`, so a machine credential presenting its own token can self-check
 `service_account` tuples the same way a human token self-checks `user` ones. An
-RFC 8693 delegated/token-exchange token stays a `user:<sub>` subject regardless —
+[RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) delegated/token-exchange token stays a `user:<sub>` subject regardless —
 only an autonomous machine token classifies as `service_account:`. Model machine
 identities with `type service_account` and admit it in relevant type restrictions
 (`viewer: [user, service_account]`) to put them in the same graph as humans; see
@@ -319,7 +319,7 @@ cookie is used automatically.
   silently — delete the tuples first. The action is audited (`admin.fga_reset`).
 - **Auditing.** Model writes, tuple writes/deletes, and resets are recorded as admin
   audit events, visible under **Audit Logs** in the dashboard.
-- **Metrics.** The engine exports Prometheus metrics — `authorizer_fga_checks_total`
+- **Metrics.** The engine exports [Prometheus](https://prometheus.io) metrics — `authorizer_fga_checks_total`
   (allow/deny/error), `authorizer_fga_check_duration_seconds`, and
   `authorizer_fga_operations_total` — for adoption tracking and denial/error alerting.
   Delegated (agent) callers additionally report

--- a/docs/core/client-registry.md
+++ b/docs/core/client-registry.md
@@ -108,7 +108,7 @@ Client responses never contain a secret or secret hash — there is no `client_s
 
 ## Authenticating: `client_credentials`
 
-Service accounts get tokens with the RFC 6749 §4.4 grant at `POST /oauth/token`:
+Service accounts get tokens with the [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) §4.4 grant at `POST /oauth/token`:
 
 ```bash
 curl -s -X POST $AUTHORIZER_URL/oauth/token \
@@ -167,7 +167,7 @@ A deactivated (`is_active: false`) service account is denied even while its alre
 
 ## Secretless authentication: client assertions & trusted issuers
 
-Instead of a stored secret, a service account can authenticate with a signed JWT it already possesses — a Kubernetes ServiceAccount token or a SPIFFE JWT-SVID — presented as an RFC 7523 `client_assertion`:
+Instead of a stored secret, a service account can authenticate with a signed JWT it already possesses — a Kubernetes ServiceAccount token or a [SPIFFE](https://spiffe.io) JWT-SVID — presented as an [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) `client_assertion`:
 
 ```
 POST /oauth/token

--- a/docs/core/databases.md
+++ b/docs/core/databases.md
@@ -51,6 +51,12 @@ Authorizer v2 configures the database via CLI flags. The required flags are `--d
   --database-type=sqlite --database-url=test.db
   ```
 
+- [libSQL / Turso](https://turso.tech/)
+
+  ```bash
+  --database-type=libsql --database-url="libsql://your-db.turso.io?authToken=YOUR_TOKEN"
+  ```
+
 - [SQLServer](https://www.microsoft.com/en-us/sql-server/)
 
   ```bash

--- a/docs/core/fga-guide.md
+++ b/docs/core/fga-guide.md
@@ -533,7 +533,7 @@ instance's `--roles` JWT claim — see [the note on roles](./authorization#3-gra
 
 ## Part 3 — DSL construct reference
 
-Every relationship-definition construct OpenFGA's DSL (`schema 1.1`) supports, and how
+Every relationship-definition construct [OpenFGA](https://openfga.dev)'s DSL (`schema 1.1`) supports, and how
 it behaves through `check_permissions` / `list_permissions`. All of these are verified
 against Authorizer's embedded engine — except where explicitly marked unsupported.
 

--- a/docs/core/graphql-api.md
+++ b/docs/core/graphql-api.md
@@ -100,10 +100,10 @@ It returns `Meta` type with the following possible values
 | `is_basic_authentication_enabled` | It gives information, if basic auth is enabled or not         |
 | `is_magic_link_login_enabled`     | It gives information if password less login is enabled or not |
 | `is_sign_up_enabled`              | It gives information if sign up is enabled or not             |
-| `is_totp_mfa_enabled`             | Whether TOTP MFA enrollment and login are available           |
+| `is_totp_mfa_enabled`             | Whether [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) MFA enrollment and login are available           |
 | `is_email_otp_mfa_enabled`        | Whether email OTP MFA enrollment and login are available (requires SMTP configured) |
-| `is_sms_otp_mfa_enabled`          | Whether SMS OTP MFA enrollment and login are available (requires Twilio configured) |
-| `is_webauthn_enabled`             | Whether WebAuthn/passkey enrollment is available              |
+| `is_sms_otp_mfa_enabled`          | Whether SMS OTP MFA enrollment and login are available (requires [Twilio](https://www.twilio.com) configured) |
+| `is_webauthn_enabled`             | Whether [WebAuthn](https://www.w3.org/TR/webauthn-2/)/passkey enrollment is available              |
 
 **Sample Query**
 
@@ -2007,7 +2007,7 @@ query {
 
 #### `_fga_expand`
 
-Expand the relationship/userset tree for a relation on an object (admin only — reveals the access graph). Useful for debugging how access is derived. Returns `{ tree }` — the OpenFGA userset tree serialized as a JSON string.
+Expand the relationship/userset tree for a relation on an object (admin only — reveals the access graph). Useful for debugging how access is derived. Returns `{ tree }` — the [OpenFGA](https://openfga.dev) userset tree serialized as a JSON string.
 
 Input `params` (`FgaExpandInput`): `{ relation: String!, object: String! }`.
 

--- a/docs/core/grpc.md
+++ b/docs/core/grpc.md
@@ -216,7 +216,7 @@ Each message mirrors its GraphQL/REST counterpart — see the linked
 
 ### `Login`
 
-*Public.* Authenticate with email/phone + password. Returns tokens, or an MFA challenge flag when OTP/TOTP is enabled. Mirrors [`login`](./graphql-api#login).
+*Public.* Authenticate with email/phone + password. Returns tokens, or an MFA challenge flag when OTP/[TOTP](https://datatracker.ietf.org/doc/html/rfc6238) is enabled. Mirrors [`login`](./graphql-api#login).
 
 ### `MagicLinkLogin`
 
@@ -480,7 +480,7 @@ Manage machine/workload identity clients (`service_account` and similar client t
 
 ### Trusted Issuers
 
-Manage external JWT issuers used for RFC 7523 `private_key_jwt` client assertions. See [Workload Identity](../enterprise/workload-identity).
+Manage external JWT issuers used for [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) `private_key_jwt` client assertions. See [Workload Identity](../enterprise/workload-identity).
 
 #### `AddTrustedIssuer`
 
@@ -488,7 +488,7 @@ Manage external JWT issuers used for RFC 7523 `private_key_jwt` client assertion
 
 #### `UpdateTrustedIssuer`
 
-*Admin-only.* Update an issuer's name, JWKS URL, expected audience, active state, or SPIFFE refresh hint.
+*Admin-only.* Update an issuer's name, JWKS URL, expected audience, active state, or [SPIFFE](https://spiffe.io) refresh hint.
 
 #### `DeleteTrustedIssuer`
 
@@ -504,7 +504,7 @@ Manage external JWT issuers used for RFC 7523 `private_key_jwt` client assertion
 
 ### SAML IdP
 
-Manage Authorizer acting as a SAML 2.0 identity provider for downstream service providers, plus IdP signing-key rotation. See [SAML IdP](../enterprise/saml-idp).
+Manage Authorizer acting as a [SAML 2.0](https://www.oasis-open.org/standard/saml/) identity provider for downstream service providers, plus IdP signing-key rotation. See [SAML IdP](../enterprise/saml-idp).
 
 #### `CreateSamlServiceProvider`
 

--- a/docs/core/mcp.md
+++ b/docs/core/mcp.md
@@ -147,7 +147,7 @@ discovery path instead of falling back to OIDC discovery.
 The [`with-mcp`](https://github.com/authorizerdev/examples/tree/main/with-mcp) example
 builds this end to end: a ~150-line Express MCP server that validates Authorizer-issued
 JWTs (issuer + `aud`) and a client walkthrough that goes 401 → RFC 9728 discovery →
-`client_credentials` (rejected — wrong `aud`) → RFC 8693 token exchange with
+`client_credentials` (rejected — wrong `aud`) → [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange with
 `resource=<mcp-server-uri>` → 200. Its own bonus section documents this page's
 built-in stdio server too, for the "which one do I want" question.
 

--- a/docs/core/metrics-monitoring.md
+++ b/docs/core/metrics-monitoring.md
@@ -33,7 +33,7 @@ Returns `503` with `{"status":"not ready","error":"storage unavailable"}` when t
 
 ### `/metrics` - Prometheus Metrics
 
-Serves all metrics in Prometheus exposition format.
+Serves all metrics in [Prometheus](https://prometheus.io) exposition format.
 
 **`/metrics` is never on the main HTTP server.** It is always served by a **separate minimal HTTP server** that runs in parallel with the main Gin app (same pattern as running distinct app and metrics listeners). By default `--http-port` is `8080` and `--metrics-port` is `8081`; **`--http-port` and `--metrics-port` must differ** or the process exits at startup.
 
@@ -137,7 +137,7 @@ limits themselves.
 
 ### Authorization (FGA) Metrics
 
-These metrics cover the embedded fine-grained authorization (OpenFGA) engine. They
+These metrics cover the embedded fine-grained authorization ([OpenFGA](https://openfga.dev)) engine. They
 appear only once FGA is enabled and the corresponding operation has run at least
 once. See [Authorization (FGA)](./authorization).
 

--- a/docs/core/oauth2-oidc.md
+++ b/docs/core/oauth2-oidc.md
@@ -5,7 +5,7 @@ title: OAuth 2.0, OIDC & SSO
 
 # OAuth 2.0, OpenID Connect & SSO
 
-Authorizer is a fully conformant OAuth 2.0 and OpenID Connect (OIDC) provider. You can:
+Authorizer is a fully conformant OAuth 2.0 and [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) (OIDC) provider. You can:
 
 - **Use it standalone** as an SSO identity provider for your own apps — any OIDC-compliant client library "just works" against its Discovery URL.
 - **Federate it into an existing SSO** (Auth0, Okta, Keycloak, etc.) as an upstream OIDC identity provider.
@@ -22,15 +22,15 @@ This page is the one-stop reference for every endpoint, parameter, and integrati
 | OIDC Hybrid Flow (§3.3)               | Implemented   | `code id_token`, `code token`, `code id_token token`, `id_token token` |
 | OIDC RP-Initiated Logout 1.0          | Implemented   | `post_logout_redirect_uri`, `state` echo, `id_token_hint`          |
 | OIDC Back-Channel Logout 1.0          | Implemented   | Opt-in via `--backchannel-logout-uri`                              |
-| RFC 6749 (OAuth 2.0)                  | Implemented   | Authorization Code + Refresh Token + Implicit + Client Credentials grants |
+| [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) (OAuth 2.0)                  | Implemented   | Authorization Code + Refresh Token + Implicit + Client Credentials grants |
 | RFC 6750 (Bearer Token)               | Implemented   | `WWW-Authenticate` on 401                                          |
 | RFC 7009 (Token Revocation)           | Implemented   | Returns 200 for invalid tokens                                     |
 | RFC 7517 (JWK)                        | Implemented   | RSA, ECDSA, HMAC; manual multi-key rotation                        |
-| RFC 7523 (JWT client assertions)      | Implemented   | `private_key_jwt` via [trusted issuers](../enterprise/workload-identity) — K8s SA tokens, SPIFFE JWT-SVIDs |
-| RFC 7636 (PKCE)                       | Implemented   | `S256` and `plain` methods; defaults to `plain` when the method is omitted (§4.2) |
+| [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) (JWT client assertions)      | Implemented   | `private_key_jwt` via [trusted issuers](../enterprise/workload-identity) — K8s SA tokens, [SPIFFE](https://spiffe.io) JWT-SVIDs |
+| [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) (PKCE)                       | Implemented   | `S256` and `plain` methods; defaults to `plain` when the method is omitted (§4.2) |
 | RFC 7662 (Token Introspection)        | Implemented   | Non-disclosure for inactive tokens                                 |
 | RFC 8414 (Authorization Server Metadata) | Implemented | `/.well-known/oauth-authorization-server` — alias of the OIDC discovery document |
-| RFC 8693 (Token Exchange)             | Implemented   | [Delegation-only profile](../enterprise/token-exchange) with nested `act` chain |
+| [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) (Token Exchange)             | Implemented   | [Delegation-only profile](../enterprise/token-exchange) with nested `act` chain |
 | RFC 8707 (Resource Indicators)        | Implemented   | Optional `resource` on `/authorize` + `/oauth/token` (authorization code flow); exactly one required on the token-exchange grant |
 
 **Not yet implemented** (tracked for future releases): RFC 7591 dynamic client registration, RFC 9101 JAR / Request Object, OIDC Session Management iframe, front-channel logout, automated time-based key rotation.

--- a/docs/core/rest-api.md
+++ b/docs/core/rest-api.md
@@ -229,7 +229,7 @@ Register a new user. Request/response fields match [`signup`](./graphql-api#sign
 ### `POST /v1/login`
 
 Authenticate with email/phone + password. Returns tokens, or an MFA challenge flag
-(`should_show_email_otp_screen` / `should_show_totp_screen`) when OTP/TOTP is enabled.
+(`should_show_email_otp_screen` / `should_show_totp_screen`) when OTP/[TOTP](https://datatracker.ietf.org/doc/html/rfc6238) is enabled.
 Mirrors [`login`](./graphql-api#login).
 
 ```bash
@@ -280,7 +280,7 @@ Generates a fresh TOTP secret, QR image, and recovery codes for the caller to en
 
 ### `POST /v1/webauthn_registration_options`
 
-Returns the WebAuthn creation options (an opaque JSON string) to hand to `navigator.credentials.create()`. Works for an already-authenticated caller adding a passkey, or for a caller in the withheld first-time MFA-offer state identified by the MFA session cookie.
+Returns the [WebAuthn](https://www.w3.org/TR/webauthn-2/) creation options (an opaque JSON string) to hand to `navigator.credentials.create()`. Works for an already-authenticated caller adding a passkey, or for a caller in the withheld first-time MFA-offer state identified by the MFA session cookie.
 
 ### `POST /v1/webauthn_registration_verify`
 
@@ -798,7 +798,7 @@ List fully-qualified user ids that have a relation on an object (reveals the acc
 
 #### `POST /v1/admin/fga/expand`
 
-Expand the relationship/userset tree for a relation on an object (admin-only; useful for debugging). Returns the OpenFGA userset tree as a JSON string.
+Expand the relationship/userset tree for a relation on an object (admin-only; useful for debugging). Returns the [OpenFGA](https://openfga.dev) userset tree as a JSON string.
 
 **Request body**
 
@@ -833,20 +833,20 @@ shapes and examples: [Client Registry guide](./client-registry).
 
 ### Trusted Issuers
 
-Manage external JWT issuers for RFC 7523 `private_key_jwt` client assertions. All
+Manage external JWT issuers for [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) `private_key_jwt` client assertions. All
 admin-only. Field-level request/response shapes: [Workload Identity](../enterprise/workload-identity).
 
 | Endpoint                                  | Description                                                          |
 | ------------------------------------------ | --------------------------------------------------------------------- |
 | `POST /v1/admin/add_trusted_issuer`        | Register an issuer for a client (`subject_claim` defaults to `sub`). |
-| `POST /v1/admin/update_trusted_issuer`     | Update name, JWKS URL, expected audience, active state, or SPIFFE hint. |
+| `POST /v1/admin/update_trusted_issuer`     | Update name, JWKS URL, expected audience, active state, or [SPIFFE](https://spiffe.io) hint. |
 | `POST /v1/admin/delete_trusted_issuer`     | Delete a trusted issuer by id.                                        |
 | `POST /v1/admin/trusted_issuer`            | Get a single trusted issuer by id.                                    |
 | `POST /v1/admin/trusted_issuers`           | List trusted issuers, optionally filtered by client id.              |
 
 ### SAML IdP
 
-Manage Authorizer acting as a SAML 2.0 IdP for downstream service providers, plus IdP
+Manage Authorizer acting as a [SAML 2.0](https://www.oasis-open.org/standard/saml/) IdP for downstream service providers, plus IdP
 signing-key rotation. All admin-only. Field-level request/response shapes: [SAML IdP](../enterprise/saml-idp).
 
 | Endpoint                                        | Description                                                          |
@@ -911,7 +911,7 @@ upstream `client_secret` is stored encrypted and never returned. Field-level sha
 
 ### SCIM
 
-Inbound SCIM 2.0 provisioning endpoints, one per organization. The bearer token is
+Inbound [SCIM 2.0](https://datatracker.ietf.org/doc/html/rfc7644) provisioning endpoints, one per organization. The bearer token is
 returned exactly once — at creation and at rotation — and is never retrievable
 afterwards. Field-level shapes: [SCIM](../enterprise/scim).
 

--- a/docs/core/security.md
+++ b/docs/core/security.md
@@ -107,7 +107,7 @@ proxy you **must** set this flag, otherwise:
 | Per-IP rate limiting | All requests appear to come from the proxy → one rate-limit bucket for the entire fleet → trivial to exhaust. |
 | Audit logs | Every event is recorded with the proxy IP, not the user's. |
 | CSRF same-origin enforcement | Uses the request `Host` header (unaffected); but combined with the wrong client IP makes investigations harder. |
-| Prometheus metrics | `authorizer_http_requests_total` labelled by proxy IP only. |
+| [Prometheus](https://prometheus.io) metrics | `authorizer_http_requests_total` labelled by proxy IP only. |
 
 ### Common deployments
 
@@ -227,7 +227,7 @@ The following headers are always set:
 
 Token endpoint responses (`/oauth/token`) additionally set
 `Cache-Control: no-store, no-cache, must-revalidate, private` and
-`Pragma: no-cache` per RFC 6749 §5.1.
+`Pragma: no-cache` per [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) §5.1.
 
 Two opt-in flags:
 
@@ -310,7 +310,7 @@ No flags. The protection applies to:
 
 ## OTP and TOTP at rest
 
-OTP and TOTP secrets are now protected at rest:
+OTP and [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) secrets are now protected at rest:
 
 - **OTPs (email/SMS one-time codes):** stored as HMAC-SHA256 digests
   keyed by `--encryption-key`. The verifier hashes the candidate and
@@ -406,7 +406,7 @@ failed to decrypt stored TOTP secret; check that --encryption-key (or --jwt-secr
 
 ## Multi-factor authentication (MFA) & Passkeys
 
-MFA methods — TOTP, email OTP, SMS OTP, and WebAuthn/passkey as a second
+MFA methods — TOTP, email OTP, SMS OTP, and [WebAuthn](https://www.w3.org/TR/webauthn-2/)/passkey as a second
 factor — are **enabled by default**. `--enforce-mfa` defaults to `false`:
 MFA is optional and skippable unless you turn enforcement on. See
 [Server Configuration](./server-config#multi-factor-authentication-mfa--webauthnpasskeys)
@@ -424,7 +424,7 @@ configured):
 |---|---|
 | `is_totp_mfa_enabled` | MFA enabled and `--disable-totp-login` is not set |
 | `is_email_otp_mfa_enabled` | MFA enabled, `--disable-email-otp` is not set, and SMTP is configured |
-| `is_sms_otp_mfa_enabled` | MFA enabled, `--disable-sms-otp` is not set, and Twilio is configured |
+| `is_sms_otp_mfa_enabled` | MFA enabled, `--disable-sms-otp` is not set, and [Twilio](https://www.twilio.com) is configured |
 | `is_webauthn_enabled` | MFA enabled and `--disable-webauthn-mfa` is not set — this reflects WebAuthn's availability **as an MFA factor only**; primary passkey login/registration has no flag and is always available regardless of this field |
 | `is_mfa_enforced` | mirrors `--enforce-mfa` |
 
@@ -652,7 +652,7 @@ This kills the user-enumeration attack surface entirely.
 
 ## Fine-grained authorization
 
-Authorizer ships an embedded **OpenFGA** (ReBAC) engine, and access checks **fail closed** — a `check_permissions` for a relation that the relationship tuples don't grant is denied, and any engine or store error denies rather than allows. There is no permissive "log but allow" mode. See [Authorization (FGA)](./authorization) for the authorization model, admin mutations, and per-endpoint usage.
+Authorizer ships an embedded **[OpenFGA](https://openfga.dev)** (ReBAC) engine, and access checks **fail closed** — a `check_permissions` for a relation that the relationship tuples don't grant is denied, and any engine or store error denies rather than allows. There is no permissive "log but allow" mode. See [Authorization (FGA)](./authorization) for the authorization model, admin mutations, and per-endpoint usage.
 
 ---
 

--- a/docs/core/server-config.md
+++ b/docs/core/server-config.md
@@ -139,8 +139,8 @@ See the [Auth behavior mapping](../migration/v1-to-v2#auth-behavior) for exact c
 ### Multi-factor authentication (MFA) & WebAuthn/passkeys
 
 **Breaking change**: `--enable-mfa`, `--enable-totp-login`, `--enable-email-otp`,
-and `--enable-sms-otp` are **removed**. TOTP, email OTP, SMS OTP, and
-WebAuthn/passkey-as-MFA are now all **on by default**; opt out per method with
+and `--enable-sms-otp` are **removed**. [TOTP](https://datatracker.ietf.org/doc/html/rfc6238), email OTP, SMS OTP, and
+[WebAuthn](https://www.w3.org/TR/webauthn-2/)/passkey-as-MFA are now all **on by default**; opt out per method with
 the `--disable-*` flags below. `--enforce-mfa` also flipped its default from
 `true` to `false` — MFA is now optional and skippable unless you explicitly
 enforce it.
@@ -173,7 +173,7 @@ enforce it.
   takes effect when SMTP is configured (`--smtp-*`); otherwise email OTP is
   unavailable regardless of this flag.
 - **`--disable-sms-otp`** (default `false`): disable SMS-OTP MFA. Only takes
-  effect when Twilio is configured (`--twilio-*`); otherwise SMS OTP is
+  effect when [Twilio](https://www.twilio.com) is configured (`--twilio-*`); otherwise SMS OTP is
   unavailable regardless of this flag.
 
 Effective availability of each method is exposed on the public `meta`
@@ -346,7 +346,7 @@ New in v2:
 - **`--graphql-max-body-bytes`** (default `1048576`, 1 MiB): max GraphQL request body size.
 
 `GET /graphql` is no longer accepted — clients must POST. Rejections are
-counted in the `authorizer_graphql_limit_rejections_total` Prometheus
+counted in the `authorizer_graphql_limit_rejections_total` [Prometheus](https://prometheus.io)
 metric, labelled by limit kind. See
 [GraphQL hardening](./security#graphql-hardening) for details.
 
@@ -360,7 +360,7 @@ metric, labelled by limit kind. See
   --authorization-log-all-checks=false
 ```
 
-- **`--fga-store`**: backing store for the embedded OpenFGA engine — one of `sqlite`, `postgres`, `mysql`, or `memory`. Only needed when the main database is NoSQL (see paragraph below); for SQL main databases the engine reuses that database automatically.
+- **`--fga-store`**: backing store for the embedded [OpenFGA](https://openfga.dev) engine — one of `sqlite`, `postgres`, `mysql`, or `memory`. Only needed when the main database is NoSQL (see paragraph below); for SQL main databases the engine reuses that database automatically.
 - **`--fga-store-url`**: connection string for the FGA store when `--fga-store` is set to a database driver.
 - **`--include-permissions-in-token`** (default `false`): when true, the access token's claims include the caller's flat `(resource, scope)` grant list. Useful for stateless downstream services that don't want to round-trip back to Authorizer per check.
 - **`--authorization-log-all-checks`** (default `false`): audit-log every `CheckPermission` call, not just denials. Diagnostic; expensive at scale.

--- a/docs/core/sso-guide.md
+++ b/docs/core/sso-guide.md
@@ -35,7 +35,7 @@ Every app talks to Authorizer using standard **OIDC Discovery**. Point your app 
 |---------|---------|
 | **Single user store** | One account per person across all apps. No duplicate credentials, no sync headaches. |
 | **One login, all apps** | Session cookie means users authenticate once. Subsequent apps get silent SSO via `prompt=none`. |
-| **Centralized MFA** | TOTP, email OTP, or SMS OTP configured once per user, enforced everywhere. |
+| **Centralized MFA** | [TOTP](https://datatracker.ietf.org/doc/html/rfc6238), email OTP, or SMS OTP configured once per user, enforced everywhere. |
 | **Unified roles** | Assign roles centrally; each app reads the `roles` claim from the JWT and enforces its own authorization. |
 | **Self-hosted & sovereign** | Your infrastructure, your data. No third-party vendor sees your user credentials. |
 | **Standards-based** | Full OIDC Core 1.0, OAuth 2.0, PKCE, token introspection, revocation. Any OIDC-compliant library works. |
@@ -142,7 +142,7 @@ Many tools support "Login with OIDC" out of the box. Examples:
 | Tool | Configuration |
 |------|--------------|
 | **Grafana** | Set `[auth.generic_oauth]` with `auth_url`, `token_url`, `api_url` from Authorizer's discovery endpoint. |
-| **GitLab** | Use the OmniAuth OpenID Connect provider with Authorizer's issuer URL. |
+| **GitLab** | Use the OmniAuth [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) provider with Authorizer's issuer URL. |
 | **HashiCorp Vault** | Configure the OIDC auth method with Authorizer as the provider. |
 | **MinIO** | Set `MINIO_IDENTITY_OPENID_CONFIG_URL` to Authorizer's discovery URL. |
 | **Kubernetes** | Use `--oidc-issuer-url` flag on the API server for OIDC-based kubectl authentication. |
@@ -233,7 +233,7 @@ Authorizer supports multiple login methods, all managed centrally:
 | **Email + Password** | Classic signup/login with email verification |
 | **Magic Links** | Passwordless login via email link |
 | **Email OTP** | One-time password sent to email |
-| **SMS OTP** | One-time password sent via SMS (Twilio) |
+| **SMS OTP** | One-time password sent via SMS ([Twilio](https://www.twilio.com)) |
 | **TOTP** | Time-based one-time password (Google Authenticator, Authy) |
 | **Social Logins** | Google, GitHub, Facebook, LinkedIn, Apple, Discord, Twitter, Microsoft, Twitch, Roblox |
 
@@ -301,7 +301,7 @@ Model tenants as organizations with per-org members and per-org roles, and attac
 
 ### Per-Organization SAML 2.0 SSO (SP)
 
-Authorizer acts as a SAML 2.0 Service Provider per organization: register a corporate IdP's entity ID, SSO URL, and signing certificate, and that org's users log in through their IdP with JIT provisioning. See [SAML SSO](../enterprise/org-saml).
+Authorizer acts as a [SAML 2.0](https://www.oasis-open.org/standard/saml/) Service Provider per organization: register a corporate IdP's entity ID, SSO URL, and signing certificate, and that org's users log in through their IdP with JIT provisioning. See [SAML SSO](../enterprise/org-saml).
 
 ### SAML 2.0 Identity Provider (IdP)
 
@@ -317,11 +317,11 @@ Organizations can prove ownership of an email domain — via a DNS TXT challenge
 
 ### SCIM 2.0 Provisioning (RFC 7644)
 
-Per-org inbound SCIM 2.0 endpoints let enterprise directories (Okta, Microsoft Entra ID, OneLogin) provision and deprovision users automatically. Deactivation synchronously revokes sessions and refresh tokens. See [SCIM Provisioning](../enterprise/scim).
+Per-org inbound [SCIM 2.0](https://datatracker.ietf.org/doc/html/rfc7644) endpoints let enterprise directories (Okta, Microsoft Entra ID, OneLogin) provision and deprovision users automatically. Deactivation synchronously revokes sessions and refresh tokens. See [SCIM Provisioning](../enterprise/scim).
 
 ### Workload Identity & Delegation
 
-Machines can authenticate without stored secrets (Kubernetes ServiceAccount tokens, SPIFFE JWT-SVIDs — see [Workload Identity](../enterprise/workload-identity)), and agents can act on behalf of users with attenuated, audience-bound tokens via RFC 8693 token exchange (see [Token Exchange](../enterprise/token-exchange)).
+Machines can authenticate without stored secrets (Kubernetes ServiceAccount tokens, [SPIFFE](https://spiffe.io) JWT-SVIDs — see [Workload Identity](../enterprise/workload-identity)), and agents can act on behalf of users with attenuated, audience-bound tokens via [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange (see [Token Exchange](../enterprise/token-exchange)).
 
 ---
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -34,7 +34,7 @@ The image **`EXPOSE`s `8080`, `8081`, and `9091`**. That only **documents** whic
 | Port | Role | Typical use |
 |------|------|-------------|
 | **8080** | Main HTTP (API, UI, `/healthz`, `/readyz`) | **Yes** — map to the host or front with a reverse proxy / load balancer. |
-| **8081** | Prometheus **`/metrics`** (separate listener) | **Depends** — see below. |
+| **8081** | [Prometheus](https://prometheus.io) **`/metrics`** (separate listener) | **Depends** — see below. |
 | **9091** | **gRPC** API (`AuthorizerService` + `AuthorizerAdminService`) | **Optional** — publish only if external gRPC clients connect; see [gRPC API](../core/grpc). |
 
 **Recommended defaults**

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -112,7 +112,7 @@ helm install \
 | ---- | ----------- | ------- |
 | `authorizer.http_port` | Main HTTP listen port (`--http-port`); must differ from `metrics_port` | `8080` |
 | `authorizer.metrics_port` | Dedicated `/metrics` listener port (`--metrics-port`) | `8081` |
-| `authorizer.metrics_host` | Bind address for `/metrics` (`--metrics-host`); `0.0.0.0` for in-cluster Prometheus | `0.0.0.0` |
+| `authorizer.metrics_host` | Bind address for `/metrics` (`--metrics-host`); `0.0.0.0` for in-cluster [Prometheus](https://prometheus.io) | `0.0.0.0` |
 | `authorizer.rate_limit_rps` | Per-IP sustained RPS (`--rate-limit-rps`); `0` disables | `30` |
 | `authorizer.rate_limit_burst` | Per-IP burst size (`--rate-limit-burst`) | `20` |
 | `authorizer.rate_limit_fail_closed` | On Redis/rate-limit errors, return 503 (`--rate-limit-fail-closed`) | `false` |

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -17,7 +17,7 @@ Key differences from v1:
 
 :::info `--encryption-key` (2.4.0+)
 
-Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-type`
+Encrypts [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) shared secrets and OTP digests at rest. **Required when `--jwt-type`
 is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
 start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
 distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -143,7 +143,7 @@ spec:
 
 - Declare **both** `containerPort: 8080` and **`8081`** on the pod so the API contract matches the image (`EXPOSE 8080 8081` in the Dockerfile). This is documentation for humans and tooling; it does not by itself expose traffic to the internet.
 - The **`Service`** that backs your **Ingress** (or cloud load balancer) should forward **only** the app port (**80 → 8080** in the example above). **Do not** add `8081` to that same public-facing `Service` or `Ingress`.
-- For Prometheus, scrape **`8081`** via the **pod network** or a **separate ClusterIP `Service`** (below). Set **`--metrics-host=0.0.0.0`** in `args` so the metrics listener accepts connections from other pods; without it, metrics stay on container loopback and in-cluster scrapes will fail.
+- For [Prometheus](https://prometheus.io), scrape **`8081`** via the **pod network** or a **separate ClusterIP `Service`** (below). Set **`--metrics-host=0.0.0.0`** in `args` so the metrics listener accepts connections from other pods; without it, metrics stay on container loopback and in-cluster scrapes will fail.
 
 **Summary:** expose **both** ports on the **Pod**; expose **only HTTP (8080)** to clients via Ingress/LB; keep **metrics (8081)** internal to the cluster.
 

--- a/docs/enterprise/agent-identity.md
+++ b/docs/enterprise/agent-identity.md
@@ -22,7 +22,7 @@ Give an agent a token and it holds the user's authority. Give it its own grants 
 - **Only the user's authority** — a compromised or confused agent can do anything its user can. The classic [Confused Deputy](https://en.wikipedia.org/wiki/Confused_deputy_problem): a calendar-reading agent tricked into reading payroll, because its user *can* read payroll.
 - **Only the agent's authority** — the agent acts on resources its user was never allowed near, and "on behalf of Alice" becomes a fiction.
 
-Intersecting both means an agent can only ever do things that **it** is trusted with **and** that its **user** could have done themselves. Neither identity can widen the other. This matches how WorkOS, Auth0 FGA and OpenFGA model agentic access.
+Intersecting both means an agent can only ever do things that **it** is trusted with **and** that its **user** could have done themselves. Neither identity can widen the other. This matches how WorkOS, Auth0 FGA and [OpenFGA](https://openfga.dev) model agentic access.
 
 ## Turning it on
 
@@ -198,7 +198,7 @@ A delegated action is recorded as the **agent**, with the user preserved alongsi
 | `actor_email` | *(empty — an agent has no mailbox)* |
 | `metadata` | gains `delegated_user_id=…` and, when known, `delegated_user_email=…` |
 
-Without this an agent's actions are indistinguishable from the user's own — same id, same type, no trace anything automated was involved. RFC 8693 §1.1 draws exactly this line: delegation is "A representing B" with A keeping its identity, as against impersonation where A is indistinguishable from B. It cannot be reconstructed after the fact, because the information was never written.
+Without this an agent's actions are indistinguishable from the user's own — same id, same type, no trace anything automated was involved. [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) §1.1 draws exactly this line: delegation is "A representing B" with A keeping its identity, as against impersonation where A is indistinguishable from B. It cannot be reconstructed after the fact, because the information was never written.
 
 ## Observability {#observability}
 

--- a/docs/enterprise/org-saml.md
+++ b/docs/enterprise/org-saml.md
@@ -5,7 +5,7 @@ title: Per-Org SAML 2.0 SSO
 
 # Per-Organization SAML 2.0 SSO (Service Provider)
 
-For [organizations](./organizations) whose IdP speaks SAML 2.0 (Okta, Microsoft Entra ID, ADFS, …), Authorizer acts as a **SAML Service Provider (SP)** per org. Users authenticate at the corporate IdP; Authorizer validates the signed assertion, JIT-provisions the user, and issues a normal Authorizer session.
+For [organizations](./organizations) whose IdP speaks [SAML 2.0](https://www.oasis-open.org/standard/saml/) (Okta, Microsoft Entra ID, ADFS, …), Authorizer acts as a **SAML Service Provider (SP)** per org. Users authenticate at the corporate IdP; Authorizer validates the signed assertion, JIT-provisions the user, and issues a normal Authorizer session.
 
 ## Endpoints (per org)
 

--- a/docs/enterprise/org-sso-oidc.md
+++ b/docs/enterprise/org-sso-oidc.md
@@ -104,4 +104,4 @@ Verified in the broker implementation:
 
 ## SAML instead?
 
-If the org's IdP only speaks SAML 2.0, use the [per-org SAML SP](./org-saml) — same org model, same JIT provisioning.
+If the org's IdP only speaks [SAML 2.0](https://www.oasis-open.org/standard/saml/), use the [per-org SAML SP](./org-saml) — same org model, same JIT provisioning.

--- a/docs/enterprise/saml-idp.md
+++ b/docs/enterprise/saml-idp.md
@@ -5,7 +5,7 @@ title: SAML 2.0 Identity Provider
 
 # SAML 2.0 Identity Provider (IdP)
 
-Per [organization](./organizations), Authorizer can also act as a **SAML 2.0 Identity Provider** — issuing signed assertions to downstream Service Providers (Zendesk, Salesforce, Notion, …) so their SAML-based SSO logs users in with their existing Authorizer session. This is the architectural inverse of [Authorizer as SAML SP](./org-saml): there Authorizer *consumes* an assertion from a corporate IdP; here it *produces* one for a downstream SP. Do not confuse the two — a `SAMLServiceProvider` row (this page) and an `OrgSAMLConnection` row (the SP-role doc) are unrelated tables.
+Per [organization](./organizations), Authorizer can also act as a **[SAML 2.0](https://www.oasis-open.org/standard/saml/) Identity Provider** — issuing signed assertions to downstream Service Providers (Zendesk, Salesforce, Notion, …) so their SAML-based SSO logs users in with their existing Authorizer session. This is the architectural inverse of [Authorizer as SAML SP](./org-saml): there Authorizer *consumes* an assertion from a corporate IdP; here it *produces* one for a downstream SP. Do not confuse the two — a `SAMLServiceProvider` row (this page) and an `OrgSAMLConnection` row (the SP-role doc) are unrelated tables.
 
 ```mermaid
 flowchart LR

--- a/docs/enterprise/scim.md
+++ b/docs/enterprise/scim.md
@@ -5,7 +5,7 @@ title: SCIM 2.0 Provisioning
 
 # SCIM 2.0 Provisioning
 
-Authorizer exposes a per-[organization](./organizations) inbound **SCIM 2.0** (RFC 7644) endpoint so enterprise directories (Okta, Microsoft Entra ID, OneLogin, …) can provision and deprovision that org's users automatically.
+Authorizer exposes a per-[organization](./organizations) inbound **[SCIM 2.0](https://datatracker.ietf.org/doc/html/rfc7644)** ([RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644)) endpoint so enterprise directories (Okta, Microsoft Entra ID, OneLogin, …) can provision and deprovision that org's users automatically.
 
 - Base URL: `https://your-authorizer.example/scim/v2`
 - Authentication: `Authorization: Bearer <endpoint token>` — one token per org
@@ -130,7 +130,7 @@ curl -s -G https://your-authorizer.example/scim/v2/Users \
 
 ## Group provisioning
 
-SCIM Groups (RFC 7643 §4.2) provision org-scoped groups whose membership drives both authorization and SAML assertions. A group carries only identity/metadata (`displayName`, `externalId`, timestamps) — membership is **not** a database column. It's modelled as [FGA](../core/fga-guide) relationship tuples (`group:<org>/<id>#member@user:<uid>`), the same graph that resolves roles and nested groups, so the group→role grant and the SAML group projection are both just reads of that one graph.
+SCIM Groups ([RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) §4.2) provision org-scoped groups whose membership drives both authorization and SAML assertions. A group carries only identity/metadata (`displayName`, `externalId`, timestamps) — membership is **not** a database column. It's modelled as [FGA](../core/fga-guide) relationship tuples (`group:<org>/<id>#member@user:<uid>`), the same graph that resolves roles and nested groups, so the group→role grant and the SAML group projection are both just reads of that one graph.
 
 - **Cross-org isolation (H6)**: a group is only visible/mutable through the SCIM connection whose org it belongs to; a cross-org group id resolves to `404`, indistinguishable from a nonexistent one.
 - **`displayName` uniqueness** is enforced per-org at the service layer (not a DB constraint, for identical behavior across every storage backend) — a create that collides on `displayName` with no matching `externalId` gets `409 uniqueness`.
@@ -158,7 +158,7 @@ Both the RFC/Okta filtered-path shape (`{"op":"remove","path":"members[value eq 
 
 Group membership isn't read directly by clients — it's projected into two places at session-issuance time:
 
-- **OpenFGA roles**: a role granted to a group (`role:<org>/<name>#assignee@group:<org>/<gid>#member`) is resolved transitively for every member and unioned onto the roles already minted into that org's session/JWT — see the [FGA guide](../core/fga-guide) for the tuple model (in particular [groups as subjects](../core/fga-guide#groups-as-subjects)). This only ever *adds* roles; a lookup failure derives none rather than blocking login.
+- **[OpenFGA](https://openfga.dev) roles**: a role granted to a group (`role:<org>/<name>#assignee@group:<org>/<gid>#member`) is resolved transitively for every member and unioned onto the roles already minted into that org's session/JWT — see the [FGA guide](../core/fga-guide) for the tuple model (in particular [groups as subjects](../core/fga-guide#groups-as-subjects)). This only ever *adds* roles; a lookup failure derives none rather than blocking login.
 - **SAML group assertions**: when Authorizer acts as an [IdP](./saml-idp), a user's groups *in the org the assertion is being issued for* are resolved and emitted as a multi-valued attribute (`groups` by default) — see [Group assertion](./saml-idp#group-assertion-scim-groups--saml-groups).
 
 Both projections are org-namespaced and fail closed: a user who belongs to groups/roles in other orgs never leaks them into a token or assertion issued for this org, and any FGA lookup error yields nothing rather than a partial or wrongly-scoped set.

--- a/docs/enterprise/token-exchange.md
+++ b/docs/enterprise/token-exchange.md
@@ -34,7 +34,7 @@ Three guarantees on every downstream call:
 
 ## Request
 
-`POST /oauth/token` with the calling agent authenticated as a `service_account` (`client_secret_basic`, `client_secret_post`, or an RFC 7523 [`client_assertion`](./workload-identity)):
+`POST /oauth/token` with the calling agent authenticated as a `service_account` (`client_secret_basic`, `client_secret_post`, or an [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) [`client_assertion`](./workload-identity)):
 
 | Parameter | Required | Notes |
 |-----------|----------|-------|
@@ -65,7 +65,7 @@ curl -s -X POST $AUTHORIZER_URL/oauth/token \
   -d "scope=calendar:read"
 ```
 
-**Response** (RFC 8693 §2.2):
+**Response** ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) §2.2):
 
 ```json
 {

--- a/docs/enterprise/workload-identity.md
+++ b/docs/enterprise/workload-identity.md
@@ -5,7 +5,7 @@ title: Workload Identity
 
 # Workload Identity (Secretless Client Authentication)
 
-A [`service_account` client](../core/client-registry) normally authenticates with a stored `client_secret`. Workload identity removes the stored secret entirely: the workload authenticates at `POST /oauth/token` with a signed JWT it **already possesses** — a Kubernetes projected ServiceAccount token or a SPIFFE JWT-SVID — presented as an [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523) `client_assertion`. Nothing to distribute, rotate, or leak.
+A [`service_account` client](../core/client-registry) normally authenticates with a stored `client_secret`. Workload identity removes the stored secret entirely: the workload authenticates at `POST /oauth/token` with a signed JWT it **already possesses** — a Kubernetes projected ServiceAccount token or a [SPIFFE](https://spiffe.io) JWT-SVID — presented as an [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523) `client_assertion`. Nothing to distribute, rotate, or leak.
 
 The assertion works as client authentication on both machine grants: [`client_credentials`](../core/client-registry) and [token exchange](./token-exchange).
 
@@ -25,7 +25,7 @@ sequenceDiagram
 
 ## Request
 
-No `client_id` and no `client_secret` — the client is derived from the trusted issuer the assertion's `iss` resolves to. Presenting a `client_assertion` together with any other authentication method is rejected (RFC 6749 §2.3).
+No `client_id` and no `client_secret` — the client is derived from the trusted issuer the assertion's `iss` resolves to. Presenting a `client_assertion` together with any other authentication method is rejected ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) §2.3).
 
 | Parameter | Value |
 |-----------|-------|
@@ -134,7 +134,7 @@ For testing: `kubectl create token worker -n payments --audience=https://your-au
 
 ### Online hardening: Kubernetes TokenReview
 
-Offline JWKS validation proves the token was signed by the cluster — **not** that the bound Pod/ServiceAccount still exists. A deleted pod's not-yet-expired token would still verify. For high-security workloads a trust row can opt in to online validation via `enable_token_review` + `kubernetes_api_server_url` — admin-settable fields on `_add_trusted_issuer` / `_update_trusted_issuer` (`kubernetes_api_server_url` must be a non-empty `https` URL whenever `enable_token_review` is `true`, checked at write time): after the offline checks pass, Authorizer calls the cluster's `authentication.k8s.io/v1` TokenReview API and rejects the assertion fail-closed unless the apiserver reports it still authenticated.
+Offline JWKS validation proves the token was signed by the cluster — **not** that the bound Pod/ServiceAccount still exists. A deleted pod's not-yet-expired token would still verify. For high-security workloads a trust row can opt in to online validation via `enable_token_review` + `kubernetes_api_server_url` — admin-settable fields on `_add_trusted_issuer` / `_update_trusted_issuer` (`kubernetes_api_server_url` must be a non-empty `https` URL whenever `enable_token_review` is `true`, checked at write time): after the offline checks pass, Authorizer calls the cluster's `authentication.k8s.io/v1` [TokenReview](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) API and rejects the assertion fail-closed unless the apiserver reports it still authenticated.
 
 ```graphql
 mutation {

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -16,7 +16,7 @@ All examples below use these required variables. Replace with your own values fo
 
 :::info `--encryption-key` (2.4.0+)
 
-Encrypts TOTP shared secrets and OTP digests at rest. **Required when `--jwt-type`
+Encrypts [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) shared secrets and OTP digests at rest. **Required when `--jwt-type`
 is `RS*`/`ES*`** — with no `--jwt-secret` to fall back to, the server refuses to
 start without it. With HMAC types (`HS*`) it falls back to `--jwt-secret`, but a
 distinct value is recommended: rotating the JWT secret otherwise re-keys at-rest

--- a/docs/integrations/gatsbyjs.md
+++ b/docs/integrations/gatsbyjs.md
@@ -11,11 +11,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** |                                                                                           **One-click link**                                                                                            |               **Additional information**               |
 | :----------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------: |
-|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](https://docs.authorizer.dev/deployment/railway) |
-|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](https://docs.authorizer.dev/deployment/heroku)  |
-|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](https://docs.authorizer.dev/deployment/render)  |
+|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](/deployment/railway) |
+|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](/deployment/heroku)  |
+|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](/deployment/render)  |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 

--- a/docs/integrations/hasura.md
+++ b/docs/integrations/hasura.md
@@ -13,18 +13,18 @@ To integrate Authorizer with Hasura, you will need an Authorizer instance deploy
 
 | **Infra provider** |                                                                                           **One-click link**                                                                                            |               **Additional information**               |
 | :----------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------: |
-|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](https://docs.authorizer.dev/deployment/railway) |
-|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](https://docs.authorizer.dev/deployment/heroku)  |
-|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](https://docs.authorizer.dev/deployment/render)  |
+|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](/deployment/railway) |
+|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](/deployment/heroku)  |
+|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](/deployment/render)  |
 
 OR
 
 You can also deploy Authorizer instance using
 
-- [Docker Image + Kubernetes](https://docs.authorizer.dev/deployment/kubernetes)
+- [Docker Image + Kubernetes](/deployment/kubernetes)
 - [Kubernetes HelmChart](https://github.com/authorizerdev/authorizer-helm-chart)
-- [Binary](https://docs.authorizer.dev/deployment/binary)
-- [fly.io](https://docs.authorizer.dev/deployment/flydotio)
+- [Binary](/deployment/binary)
+- [fly.io](/deployment/fly-io)
 
 > **Note:** If you are trying out with one click deployment options like railway then template is configured in a way that it will also deploy postgres + redis for you. For other deployment options, start the server with the required CLI flags:
 > ```bash

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -16,11 +16,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** |                                                                                           **One-click link**                                                                                            |               **Additional information**               |
 | :----------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------: |
-|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](https://docs.authorizer.dev/deployment/railway) |
-|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](https://docs.authorizer.dev/deployment/heroku)  |
-|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](https://docs.authorizer.dev/deployment/render)  |
+|    Railway.app     |                      <a target="_blank" href="https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic"><img src="https://railway.com/button.svg" alt="Deploy on Railway"/></a>                      | [docs](/deployment/railway) |
+|       Heroku       |  <a target="_blank" href="https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" /></a>   | [docs](/deployment/heroku)  |
+|       Render       | <a target="_blank" href="https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render"><img alt="render button" src="https://render.com/images/deploy-to-render-button.svg" /></a> | [docs](/deployment/render)  |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,10 +22,18 @@ description: Authorizer is an open-source authentication and authorization solut
 - APIs to update profile securely
 - Forgot password flow using email
 - Social logins (Google, GitHub, Facebook, LinkedIn, Apple, Discord, Twitter, Twitch, Roblox, Microsoft)
-- Role-based access management and [fine-grained authorization (FGA)](./core/authorization)
+- Role-based access management and [fine-grained authorization (FGA)](./core/authorization) via an embedded [OpenFGA](https://openfga.dev) ([Zanzibar](https://research.google/pubs/pub48190/) ReBAC) engine
 - Password-less login with magic link
-- TOTP-based multi-factor authentication
-- SMS OTP via Twilio
+- [WebAuthn](https://www.w3.org/TR/webauthn-2/) / [passkey](https://fidoalliance.org/passkeys/) registration and login
+- Multi-factor authentication: [TOTP](https://datatracker.ietf.org/doc/html/rfc6238), email OTP, SMS OTP, and passkey as a second factor
+- SMS OTP via [Twilio](https://www.twilio.com)
+- Enterprise SSO — [SAML 2.0](https://www.oasis-open.org/standard/saml/) as Service Provider and Identity Provider, OIDC federation, verified email domains, and home realm discovery ([SSO guide](./core/sso-guide))
+- [SCIM 2.0](https://datatracker.ietf.org/doc/html/rfc7644) user and group provisioning ([SCIM](./enterprise/scim))
+- [Organizations and multi-tenancy](./enterprise/organizations) with org-scoped admin roles
+- Machine-to-machine auth (`client_credentials`) and secretless workload identity — [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) client assertions, [SPIFFE](https://spiffe.io) JWT-SVIDs, Kubernetes [TokenReview](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) ([Workload Identity](./enterprise/workload-identity))
+- Agent delegation via [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange ([Token Exchange](./enterprise/token-exchange))
+- Email templating and webhooks
+- Rate limiting, security hardening, and [Prometheus](https://prometheus.io) metrics ([Metrics & Monitoring](./core/metrics-monitoring))
 - [GraphQL](./core/graphql-api), [REST](./core/rest-api), and [gRPC](./core/grpc) APIs
 - [MCP server](./core/mcp) for AI agents
 
@@ -85,9 +93,9 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
 
 Authorizer supports a wide range of databases:
 
-- PostgreSQL, MySQL, MariaDB, SQLite, SQL Server
-- MongoDB, ArangoDB, CouchDB
-- CassandraDB, ScyllaDB, DynamoDB, Couchbase
+- PostgreSQL, MySQL, MariaDB, SQLite, libSQL / Turso, SQL Server
+- MongoDB, ArangoDB, Couchbase
+- CassandraDB, ScyllaDB, DynamoDB
 - Yugabyte, PlanetScale, CockroachDB
 
 See [Databases](./core/databases) for connection string formats.
@@ -98,16 +106,16 @@ See [Databases](./core/databases) for connection string formats.
 
 ### Frontend SDKs
 
-- [JavaScript / TypeScript](https://github.com/authorizerdev/authorizer-js) — v3.2.1; user + admin client; GraphQL + REST protocols
+- [JavaScript / TypeScript](https://github.com/authorizerdev/authorizer-js) — v3.3.0; user + admin client; GraphQL + REST protocols
 - [React](https://github.com/authorizerdev/authorizer-react) — v2.x; `protocol` prop; pre-built login/signup/MFA components
-- [Vue](https://github.com/authorizerdev/authorizer-vue)
-- [Svelte](https://github.com/authorizerdev/authorizer-svelte)
+- [Vue](https://github.com/authorizerdev/authorizer-vue) — beta; no admin client or protocol selection yet
+- [Svelte](https://github.com/authorizerdev/authorizer-svelte) — beta; no admin client or protocol selection yet
 - [Flutter](https://github.com/authorizerdev/authorizer-flutter-sdk) — not released yet; no package on pub.dev
 
 ### Backend SDKs
 
 - [Go](https://github.com/authorizerdev/authorizer-go) — user + admin client; protocol selection (gRPC / REST / GraphQL); FGA helpers
-- [Python](https://github.com/authorizerdev/authorizer-python) — v0.3.0 pre-release; sync + async; admin API (`pip install --pre authorizer-py`)
+- [Python](https://github.com/authorizerdev/authorizer-py) — v0.3.0 pre-release; sync + async; admin API (`pip install --pre authorizer-py`)
 - [Node.js](https://github.com/authorizerdev/authorizer-js) — same package as the frontend SDK, works server-side
 
 See the [SDK reference](./sdks/authorizer-js) for usage docs.

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -74,7 +74,7 @@ In **v2**:
    - `--client-id` and `--client-secret` — **required**; the server will exit if they are missing.
    - `--admin-secret` — needed for admin dashboard access and admin API operations.
    - `--jwt-type` and `--jwt-secret` (for HMAC algorithms like HS256) or `--jwt-private-key` / `--jwt-public-key` (for RSA/ECDSA algorithms) — needed for token signing and verification.
-   - `--encryption-key` — encrypts TOTP secrets and OTP digests at rest (2.4.0+). **Required for RSA/ECDSA deployments**, which have no `--jwt-secret` to fall back to; the server refuses to start without it. HMAC deployments fall back to `--jwt-secret` automatically.
+   - `--encryption-key` — encrypts [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) secrets and OTP digests at rest (2.4.0+). **Required for RSA/ECDSA deployments**, which have no `--jwt-secret` to fall back to; the server refuses to start without it. HMAC deployments fall back to `--jwt-secret` automatically.
 
 ---
 
@@ -225,7 +225,7 @@ Use these v2 **CLI flags** instead of v1 env or dashboard config. Flag names use
 | Metrics bind         | `--metrics-host` (default: `127.0.0.1`) for the dedicated metrics listener |
 | `LOG_LEVEL`          | `--log-level` |
 
-**`GET /metrics` is always** on the dedicated metrics listener at **`--metrics-host`:`--metrics-port`** (default **loopback**); **`--http-port` and `--metrics-port` must differ**. Health probes remain on the HTTP port. For in-cluster Prometheus, set **`--metrics-host=0.0.0.0`** and scrape over the private network.
+**`GET /metrics` is always** on the dedicated metrics listener at **`--metrics-host`:`--metrics-port`** (default **loopback**); **`--http-port` and `--metrics-port` must differ**. Health probes remain on the HTTP port. For in-cluster [Prometheus](https://prometheus.io), set **`--metrics-host=0.0.0.0`** and scrape over the private network.
 
 ### Database
 
@@ -279,7 +279,7 @@ Use these v2 **CLI flags** instead of v1 env or dashboard config. Flag names use
 | `DISABLE_MAGIC_LINK_LOGIN`      | `--enable-magic-link-login` (inverted) |
 | `ENFORCE_MULTI_FACTOR_AUTHENTICATION` | `--enforce-mfa` (default flipped: `true` → `false`; MFA is now optional unless you set this) |
 | `DISABLE_SIGN_UP`               | `--enable-signup` (inverted) |
-| TOTP / OTP / WebAuthn           | **Breaking**: `--enable-mfa`, `--enable-totp-login`, `--enable-email-otp`, and `--enable-sms-otp` are removed. TOTP, email OTP, SMS OTP, and WebAuthn-as-MFA are now **on by default**; opt out with `--disable-totp-login`, `--disable-email-otp`, `--disable-sms-otp`, `--disable-webauthn-mfa`, or turn everything off at once with `--disable-mfa`. See [MFA & WebAuthn/passkeys flags](../core/server-config#multi-factor-authentication-mfa--webauthnpasskeys). |
+| TOTP / OTP / [WebAuthn](https://www.w3.org/TR/webauthn-2/)           | **Breaking**: `--enable-mfa`, `--enable-totp-login`, `--enable-email-otp`, and `--enable-sms-otp` are removed. TOTP, email OTP, SMS OTP, and WebAuthn-as-MFA are now **on by default**; opt out with `--disable-totp-login`, `--disable-email-otp`, `--disable-sms-otp`, `--disable-webauthn-mfa`, or turn everything off at once with `--disable-mfa`. See [MFA & WebAuthn/passkeys flags](../core/server-config#multi-factor-authentication-mfa--webauthnpasskeys). |
 | Mobile basic auth               | `--enable-mobile-basic-authentication` |
 | Phone verification              | `--enable-phone-verification` |
 
@@ -620,7 +620,7 @@ import { SignUpRequest, LoginRequest } from '@authorizerdev/authorizer-js'
 
 ## Authorization (FGA)
 
-v2 adds an embedded **OpenFGA** engine for relationship-based access control (ReBAC). You author an authorization **model** (OpenFGA DSL: types + relations), grant access with **relationship tuples** (for example `user:<id>` is `viewer` of `document:1`), and have your apps check access with `check_permissions`.
+v2 adds an embedded **[OpenFGA](https://openfga.dev)** engine for relationship-based access control (ReBAC). You author an authorization **model** (OpenFGA DSL: types + relations), grant access with **relationship tuples** (for example `user:<id>` is `viewer` of `document:1`), and have your apps check access with `check_permissions`.
 
 ### What's new
 

--- a/docs/sdks/authorizer-go/admin.md
+++ b/docs/sdks/authorizer-go/admin.md
@@ -191,7 +191,7 @@ and JS admin clients (JS supports graphql + rest only).
 
 | Method                 | Description                                                                                          | grpc | rest | gql |
 | ---------------------- | ------------------------------------------------------------------------------------------------------ | :--: | :--: | :-: |
-| `AddTrustedIssuer`     | Register an external token issuer (K8s service account, SPIFFE, OIDC) allowed to authenticate as a service account via JWT-bearer assertions. | ✓ | ✓ | ✓ |
+| `AddTrustedIssuer`     | Register an external token issuer (K8s service account, [SPIFFE](https://spiffe.io), OIDC) allowed to authenticate as a service account via JWT-bearer assertions. | ✓ | ✓ | ✓ |
 | `UpdateTrustedIssuer`  | Update a trusted issuer.                                                                                | ✓ | ✓ | ✓ |
 | `DeleteTrustedIssuer`  | **Delete a trusted issuer.** Assertions from it stop authenticating immediately.                       | ✓ | ✓ | ✓ |
 | `GetTrustedIssuer`     | Get a single trusted issuer by id.                                                                     | ✓ | ✓ | ✓ |
@@ -201,7 +201,7 @@ and JS admin clients (JS supports graphql + rest only).
 
 | Method                      | Description                                                                                     | grpc | rest | gql |
 | ---------------------------- | -------------------------------------------------------------------------------------------------| :--: | :--: | :-: |
-| `CreateSamlServiceProvider` | Register a downstream SAML 2.0 SP that Authorizer (acting as IdP) issues signed assertions to.  | ✓ | ✓ | ✓ |
+| `CreateSamlServiceProvider` | Register a downstream [SAML 2.0](https://www.oasis-open.org/standard/saml/) SP that Authorizer (acting as IdP) issues signed assertions to.  | ✓ | ✓ | ✓ |
 | `UpdateSamlServiceProvider` | Update a downstream SP's name, endpoints, certificate, attribute mapping, or active state.       | ✓ | ✓ | ✓ |
 | `DeleteSamlServiceProvider` | **Delete a downstream SP.** SSO assertions to it stop being issued immediately.                  | ✓ | ✓ | ✓ |
 | `GetSamlServiceProvider`    | Get a single downstream SP by id.                                                                | ✓ | ✓ | ✓ |

--- a/docs/sdks/authorizer-go/functions.md
+++ b/docs/sdks/authorizer-go/functions.md
@@ -103,7 +103,7 @@ All take a `headers` map with a bearer token (or, if the caller doesn't have one
 | `RevokeToken`  | `RevokeToken(req *RevokeTokenRequest) (*Response, error)` | `*Response` |
 | `Revoke`       | `Revoke(req *RevokeRequest) (*Response, error)` | `*Response` |
 
-`GetToken` posts a form-encoded (`application/x-www-form-urlencoded`) request to `/oauth/token` and supports four grants: `authorization_code` (default, needs `code` + `code_verifier`), `refresh_token`, `client_credentials` (RFC 6749 §4.4), and RFC 8693 token exchange. The `client_credentials` and token-exchange grants are **machine / agent-to-agent flows — server-side only**: never send `client_secret`, `client_assertion`, or a `subject_token`/`actor_token` to untrusted or browser code.
+`GetToken` posts a form-encoded (`application/x-www-form-urlencoded`) request to `/oauth/token` and supports four grants: `authorization_code` (default, needs `code` + `code_verifier`), `refresh_token`, `client_credentials` ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) §4.4), and [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange. The `client_credentials` and token-exchange grants are **machine / agent-to-agent flows — server-side only**: never send `client_secret`, `client_assertion`, or a `subject_token`/`actor_token` to untrusted or browser code.
 
 #### Machine-to-machine (client_credentials)
 

--- a/docs/sdks/authorizer-go/index.md
+++ b/docs/sdks/authorizer-go/index.md
@@ -167,7 +167,7 @@ The SDK provides the following methods:
 - `CheckPermissions` -- Evaluate one or more permission checks (FGA)
 - `ListPermissions` -- List objects the subject holds a permission on (FGA)
 - `GetMetaData` -- Get server metadata / enabled feature flags
-- `GetToken` -- Exchange a grant (`authorization_code`, `refresh_token`, `client_credentials`, or RFC 8693 `token-exchange`) for a token at `/oauth/token` -- covers M2M and workload-identity flows
+- `GetToken` -- Exchange a grant (`authorization_code`, `refresh_token`, `client_credentials`, or [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) `token-exchange`) for a token at `/oauth/token` -- covers M2M and workload-identity flows
 - `ExecuteGraphQL` -- Run a raw GraphQL request against the instance
 - `ResendOTP` -- Resend a one-time code
 - `ResendVerifyEmail` -- Resend the email verification link
@@ -176,7 +176,7 @@ The SDK provides the following methods:
 - `SkipMfaSetup` -- Skip optional MFA setup and issue the withheld access token
 - `EmailOtpMfaSetup` -- Start email-OTP MFA enrollment
 - `SmsOtpMfaSetup` -- Start SMS-OTP MFA enrollment
-- `TotpMfaSetup` -- Start TOTP MFA enrollment
+- `TotpMfaSetup` -- Start [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) MFA enrollment
 - `DeactivateAccount` -- Deactivate the authenticated user's own account
 - `WebauthnRegistrationOptions` -- Get a passkey creation challenge
 - `WebauthnRegistrationVerify` -- Complete passkey enrollment

--- a/docs/sdks/authorizer-js/admin.md
+++ b/docs/sdks/authorizer-js/admin.md
@@ -156,7 +156,7 @@ protocol returns a clear error rather than emitting a 404.
 
 #### OAuth clients (service accounts / M2M)
 
-Registered OAuth clients used by the `client_credentials` and RFC 8693 token-exchange grants
+Registered OAuth clients used by the `client_credentials` and [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token-exchange grants
 (see [`getToken`](/sdks/authorizer-js/functions#--gettoken)). `client_secret` is returned
 exactly once, at creation and at rotation, and is never projected back afterwards.
 
@@ -171,8 +171,8 @@ exactly once, at creation and at rotation, and is never projected back afterward
 
 #### Trusted issuers (secretless client authentication)
 
-External token issuers trusted to authenticate a service account via RFC 7523
-`client_assertion` (Kubernetes SA tokens, SPIFFE JWT-SVIDs, cloud OIDC tokens) instead of a
+External token issuers trusted to authenticate a service account via [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)
+`client_assertion` (Kubernetes SA tokens, [SPIFFE](https://spiffe.io) JWT-SVIDs, cloud OIDC tokens) instead of a
 shared secret.
 
 | Method                  | Description                                              | rest | gql |
@@ -203,7 +203,7 @@ domains gained REST routes in server 2.4.0; on older servers these are GraphQL o
 #### Org SSO connections
 
 Per-organization upstream identity providers. `createOrgOIDCConnection` brokers Authorizer as
-an OIDC Relying Party; `createOrgSAMLConnection` brokers Authorizer as a SAML 2.0 Service
+an OIDC Relying Party; `createOrgSAMLConnection` brokers Authorizer as a [SAML 2.0](https://www.oasis-open.org/standard/saml/) Service
 Provider. Upstream secrets/certificates are accepted on write but never projected back.
 
 | Method                       | Description                                                       | rest | gql |
@@ -236,7 +236,7 @@ issues signed SAML assertions to, plus the per-org IdP signing keypairs used to 
 
 #### SCIM endpoints
 
-Per-org inbound SCIM 2.0 provisioning credential. The bearer token is returned exactly once,
+Per-org inbound [SCIM 2.0](https://datatracker.ietf.org/doc/html/rfc7644) provisioning credential. The bearer token is returned exactly once,
 at creation and at rotation, and is never projected back afterwards.
 
 | Method                | Description                                                     | rest | gql |

--- a/docs/sdks/authorizer-js/functions.md
+++ b/docs/sdks/authorizer-js/functions.md
@@ -130,7 +130,7 @@ It accepts JSON object as a parameter with following keys
 | `refresh_token`          | Refresh token used to get the new access token. Required in case of `refresh_token` grant type                               | false    |
 | `client_secret`          | Service-account secret. Used with `client_credentials`. Server-side only.                                                     | false    |
 | `scope`                  | Space-delimited OAuth2 scope. Omit for `client_credentials` to get the service account's full allowed scope set.             | false    |
-| `client_assertion`       | RFC 7523 JWT-bearer client credential (secretless workload identity: K8s SA tokens, SPIFFE JWT-SVIDs, cloud OIDC tokens).     | false    |
+| `client_assertion`       | [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) JWT-bearer client credential (secretless workload identity: K8s SA tokens, [SPIFFE](https://spiffe.io) JWT-SVIDs, cloud OIDC tokens).     | false    |
 | `client_assertion_type`  | Type of `client_assertion`. Use the exported `CLIENT_ASSERTION_TYPE_JWT_BEARER` constant.                                     | false    |
 | `subject_token`          | The authority being exercised (the user's token). Required for token exchange.                                               | false    |
 | `subject_token_type`     | Type of `subject_token`. Use the exported `TOKEN_TYPE_ACCESS_TOKEN` / `TOKEN_TYPE_JWT` constants.                             | false    |
@@ -623,10 +623,10 @@ It returns the following keys in response `data` object
 | `is_multi_factor_auth_enabled`             | It gives information if multi-factor authentication is enabled      |
 | `is_mobile_basic_authentication_enabled`   | It gives information if mobile (phone number) basic auth is enabled |
 | `is_phone_verification_enabled`            | It gives information if phone verification is enabled               |
-| `is_totp_mfa_enabled`                      | It gives information if TOTP is available as an MFA method          |
+| `is_totp_mfa_enabled`                      | It gives information if [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) is available as an MFA method          |
 | `is_email_otp_mfa_enabled`                 | It gives information if email OTP is available as an MFA method     |
 | `is_sms_otp_mfa_enabled`                   | It gives information if SMS OTP is available as an MFA method       |
-| `is_webauthn_enabled`                      | It gives information if WebAuthn/passkeys are available as an MFA method |
+| `is_webauthn_enabled`                      | It gives information if [WebAuthn](https://www.w3.org/TR/webauthn-2/)/passkeys are available as an MFA method |
 | `is_mfa_enforced`                          | It gives information if MFA is enforced for all users               |
 | `is_org_discovery_enabled`                 | It gives information if home-realm/org discovery is enabled         |
 

--- a/docs/sdks/authorizer-js/index.md
+++ b/docs/sdks/authorizer-js/index.md
@@ -20,11 +20,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** | **One-click link** | **Additional information** |
 | :----------------: | :-----------------: | :----------------------------------------------------: |
-| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](https://docs.authorizer.dev/deployment/railway) |
-| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](https://docs.authorizer.dev/deployment/heroku) |
-| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](https://docs.authorizer.dev/deployment/render) |
+| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](/deployment/railway) |
+| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](/deployment/heroku) |
+| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](/deployment/render) |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 

--- a/docs/sdks/authorizer-python/functions.md
+++ b/docs/sdks/authorizer-python/functions.md
@@ -105,7 +105,7 @@ registered passkeys.
 
 `get_token` posts a form-encoded (`application/x-www-form-urlencoded`) request to
 `/oauth/token` and supports four grants: `authorization_code` (default, needs `code` +
-`code_verifier`), `refresh_token`, `client_credentials` (RFC 6749 §4.4), and RFC 8693
+`code_verifier`), `refresh_token`, `client_credentials` ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) §4.4), and [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)
 token exchange. The `client_credentials` and token-exchange grants are **machine /
 agent-to-agent flows — server-side only**: never send `client_secret`,
 `client_assertion`, or a `subject_token`/`actor_token` to untrusted or browser code.
@@ -313,7 +313,7 @@ the constants themselves, to `grant_type`, `*_token_type`, and `client_assertion
 | `GRANT_TYPE_TOKEN_EXCHANGE`        | `"urn:ietf:params:oauth:grant-type:token-exchange"` (RFC 8693)  |
 | `TOKEN_TYPE_ACCESS_TOKEN`          | `"urn:ietf:params:oauth:token-type:access_token"`               |
 | `TOKEN_TYPE_JWT`                   | `"urn:ietf:params:oauth:token-type:jwt"`                        |
-| `CLIENT_ASSERTION_TYPE_JWT_BEARER` | `"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"` (RFC 7523) |
+| `CLIENT_ASSERTION_TYPE_JWT_BEARER` | `"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"` ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)) |
 
 ## Error handling
 

--- a/docs/sdks/authorizer-python/index.md
+++ b/docs/sdks/authorizer-python/index.md
@@ -22,11 +22,11 @@ Deploy a production-ready Authorizer instance using one of the one-click options
 
 | **Infra provider** | **One-click link** | **Additional information** |
 | :----------------: | :-----------------: | :----------------------------------------------------: |
-| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](https://docs.authorizer.dev/deployment/railway) |
-| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](https://docs.authorizer.dev/deployment/heroku) |
-| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](https://docs.authorizer.dev/deployment/render) |
+| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](/deployment/railway) |
+| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](/deployment/heroku) |
+| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](/deployment/render) |
 
-For more information check the [deployment docs](https://docs.authorizer.dev/deployment/).
+For more information check the [deployment docs](/deployment/).
 
 ## Step 2: Set up the instance
 

--- a/docs/sdks/authorizer-react/components.md
+++ b/docs/sdks/authorizer-react/components.md
@@ -71,7 +71,7 @@ const App = () => {
 A core component that includes:
 
 - social logins (incl. Discord, when enabled on the backend)
-- passkey ("Sign in with a passkey") login, shown automatically when the browser supports WebAuthn
+- passkey ("Sign in with a passkey") login, shown automatically when the browser supports [WebAuthn](https://www.w3.org/TR/webauthn-2/)
 - signup view
 - login view
 - forgot password view
@@ -293,7 +293,7 @@ const ResetPassword = () => {
 
 ## `AuthorizerVerifyOtp`
 
-A component to render the OTP/MFA verification form. It handles email/SMS OTP and TOTP codes, and — when offered alongside a code factor — a "Verify with a passkey" WebAuthn option. On SMS OTP it also attempts WebOTP auto-fill (`navigator.credentials.get({ otp: ... })`) so supporting browsers can fill the code automatically. Make sure it is used as Child of `AuthorizerProvider`.
+A component to render the OTP/MFA verification form. It handles email/SMS OTP and [TOTP](https://datatracker.ietf.org/doc/html/rfc6238) codes, and — when offered alongside a code factor — a "Verify with a passkey" WebAuthn option. On SMS OTP it also attempts WebOTP auto-fill (`navigator.credentials.get({ otp: ... })`) so supporting browsers can fill the code automatically. Make sure it is used as Child of `AuthorizerProvider`.
 
 ### Props
 

--- a/docs/sdks/authorizer-react/index.md
+++ b/docs/sdks/authorizer-react/index.md
@@ -15,11 +15,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** | **One-click link** | **Additional information** |
 | :----------------: | :-----------------: | :----------------------------------------------------: |
-| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](https://docs.authorizer.dev/deployment/railway) |
-| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](https://docs.authorizer.dev/deployment/heroku) |
-| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](https://docs.authorizer.dev/deployment/render) |
+| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](/deployment/railway) |
+| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](/deployment/heroku) |
+| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](/deployment/render) |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 

--- a/docs/sdks/authorizer-react/integration.md
+++ b/docs/sdks/authorizer-react/integration.md
@@ -208,7 +208,7 @@ function SecuritySettings() {
 ```
 
 `AuthorizerPasskeyLogin` and passkey verification only render for browsers that support
-WebAuthn — there is no backend flag to gate them on, so gate any custom UI you build
+[WebAuthn](https://www.w3.org/TR/webauthn-2/) — there is no backend flag to gate them on, so gate any custom UI you build
 around them on `isWebauthnSupported()` from `@authorizerdev/authorizer-js` the same way.
 
 ## Next.js integration

--- a/docs/sdks/authorizer-svelte/index.md
+++ b/docs/sdks/authorizer-svelte/index.md
@@ -15,11 +15,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** | **One-click link** | **Additional information** |
 | :----------------: | :-----------------: | :----------------------------------------------------: |
-| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](https://docs.authorizer.dev/deployment/railway) |
-| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](https://docs.authorizer.dev/deployment/heroku) |
-| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](https://docs.authorizer.dev/deployment/render) |
+| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](/deployment/railway) |
+| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](/deployment/heroku) |
+| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](/deployment/render) |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 
@@ -55,7 +55,7 @@ Authorizer comes with global context `authorizerContext` which is available once
 
 Configure `AuthorizerProvider` at root level in your application and import `default.css`.
 
-> Note: You can override default style with `css` variables. Check [docs](https://docs.authorizer.dev/authorizer-svelte) for more details.
+> Note: You can override default style with `css` variables. Check [docs](/sdks/authorizer-svelte) for more details.
 
 `eg: routes/+layout.svelte`
 

--- a/docs/sdks/authorizer-vue/index.md
+++ b/docs/sdks/authorizer-vue/index.md
@@ -15,11 +15,11 @@ Deploy production ready Authorizer instance using one click deployment options a
 
 | **Infra provider** | **One-click link** | **Additional information** |
 | :----------------: | :-----------------: | :----------------------------------------------------: |
-| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](https://docs.authorizer.dev/deployment/railway) |
-| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](https://docs.authorizer.dev/deployment/heroku) |
-| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](https://docs.authorizer.dev/deployment/render) |
+| Railway.app | [Deploy on Railway](https://railway.com/deploy/authorizer-1?referralCode=FEF4uT&utm_medium=integration&utm_source=template&utm_campaign=generic) | [docs](/deployment/railway) |
+| Heroku | [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/authorizerdev/authorizer-heroku) | [docs](/deployment/heroku) |
+| Render | [Deploy to Render](https://render.com/deploy?repo=https://github.com/authorizerdev/authorizer-render) | [docs](/deployment/render) |
 
-For more information check [docs](https://docs.authorizer.dev/getting-started/)
+For more information check [docs](/getting-started/)
 
 ## Step 2: Setup Instance
 


### PR DESCRIPTION
Companion to authorizerdev/authorizer.dev#23 — the same reference-link and accuracy pass, applied to the docs.

## Reference links

94 first-mention links across 34 pages. Every RFC, W3C recommendation and upstream project named in prose now links to its primary source the first time it appears on a page: SAML 2.0 (OASIS), SCIM (RFC 7643/7644), WebAuthn, OpenFGA, Zanzibar, SPIFFE, Kubernetes TokenReview, TOTP (RFC 6238), Prometheus, MCP and the OAuth RFC set.

SAML 2.0, SCIM, TOTP and Prometheus previously had **no link anywhere in the docs**, despite appearing across 9–12 pages each.

Docusaurus's `Link` already forces `target="_blank" rel="noopener noreferrer"` on off-site URLs, so no theme change was needed — 386 external links now open in a new tab, and none are missed.

## Corrections against the server repo

- **CouchDB was listed as a supported database.** It is not, and never has been — nothing in the server references it.
- **libSQL / Turso is supported but was undocumented** (`DbTypeLibSQL`, `gorm-libsql`, wired in `internal/storage/db/sql/provider.go`). Added to the database list with a connection example.
- **The feature list predated 2.4.0** — no passkeys, enterprise SSO, SCIM, organizations, workload identity or token exchange.
- **Python SDK repo** is `authorizer-py`; `authorizer-python` 404s.
- **`authorizer-js` is v3.3.0**, not v3.2.1. Vue and Svelte marked beta.

## Internal links

35 absolute `https://docs.authorizer.dev/...` self-links are now relative, so internal navigation stops opening new tabs and resolves on preview deploys. Two were dead: `/deployment/flydotio` (the page is `/deployment/fly-io`) and `/authorizer-svelte` (it is `/sdks/authorizer-svelte`).

Rebased on current `main`; `npm run build` passes with no broken-link warnings.