### PR TITLE
docs: close flag coverage gaps for same-site and unconstrained agents

### DIFF
--- a/docs/core/server-config.md
+++ b/docs/core/server-config.md
@@ -206,10 +206,36 @@ and the WebAuthn/passkey GraphQL operations.
 ```bash
 ./authorizer \
   --app-cookie-secure=true \
-  --admin-cookie-secure=true
+  --admin-cookie-secure=true \
+  --app-cookie-same-site=none
 ```
 
-Use `true` for HTTPS-only cookies in production.
+- **`--app-cookie-secure`** / **`--admin-cookie-secure`** (both default `true`):
+  use `true` for HTTPS-only cookies in production.
+- **`--app-cookie-same-site`** (default `none`): `SameSite` attribute for the
+  session cookies — one of `lax`, `strict`, or `none`.
+
+The default of `none` is what allows an app on a **different site** to complete
+a credentialed `/session` call at all. Set `lax` only when every app that reads
+the session shares this host; it is the tighter setting, but it stops
+cross-site session reads working.
+
+:::caution The value is validated at boot (2.4.0)
+
+An unrecognised value now **exits at startup** instead of silently falling back
+to `lax`. That fallback was the dangerous part: an operator who asked for
+`strict` and mistyped it got `lax` — a real downgrade from what they requested,
+with nothing anywhere saying so. A mistyped `none` went the other way and
+withheld the session cookie from cross-site apps, which presents as "login
+randomly doesn't stick" with the cause three layers away.
+:::
+
+`strict` is accepted, but note that one cookie deliberately ignores this
+setting: the short-lived OAuth `state` cookie used during social login is
+always `Lax`, or `None` when secure. A provider's callback arrives as a
+cross-site redirect — a cross-site `form_post` for Apple — and `Strict`
+withholds cookies on exactly those, so honouring `strict` there would break
+every social login on the deployment.
 
 ---
 
@@ -417,6 +443,33 @@ metric, labelled by limit kind. See
 
 - **`--fga-store`**: backing store for the embedded [OpenFGA](https://openfga.dev) engine — one of `sqlite`, `postgres`, `mysql`, or `memory`. Only needed when the main database is NoSQL (see paragraph below); for SQL main databases the engine reuses that database automatically.
 - **`--fga-store-url`**: connection string for the FGA store when `--fga-store` is set to a database driver.
+- **`--fga-allow-unconstrained-agents`** (default `false`): see below.
+
+#### `--fga-allow-unconstrained-agents`
+
+:::warning Escape hatch — changes an authorization outcome
+
+A delegated (agent-acting-for-user) permission check evaluates
+`perms(agent) ∩ perms(user)`. If the authorization model declares no
+`type agent`, the agent half **cannot be evaluated at all**.
+
+As of 2.4.0 that check is **denied**. Previously it authorized as the delegating
+user alone, which silently handed the agent the user's full authority — the
+Confused Deputy the intersection exists to prevent. A security check that cannot
+be evaluated is not a check that passes.
+
+Setting this flag to `true` restores the pre-2.4.0 behaviour while you migrate a
+model. It does not make anything more permissive than 2.3.x was, but it does
+mean **agents carry their delegating user's full authority**.
+
+Every such request is logged at warn level and recorded as `not_enforced` on the
+delegated-check metric, so the exposure shows up in dashboards rather than being
+discovered during an incident.
+
+The fix is to add `type agent` to your model — see
+[Agent identity](../enterprise/agent-identity). Grant your agents *before*
+deploying the model, or their calls start being denied.
+:::
 - **`--include-permissions-in-token`** (default `false`): when true, the access token's claims include the caller's flat `(resource, scope)` grant list. Useful for stateless downstream services that don't want to round-trip back to Authorizer per check.
 - **`--authorization-log-all-checks`** (default `false`): audit-log every `CheckPermission` call, not just denials. Diagnostic; expensive at scale.
 

--- a/docs/enterprise/agent-identity.md
+++ b/docs/enterprise/agent-identity.md
@@ -26,7 +26,7 @@ Intersecting both means an agent can only ever do things that **it** is trusted 
 
 ## Turning it on
 
-**Declare `type agent` in your authorization model.** That is the whole opt-in — there is no flag.
+**Declare `type agent` in your authorization model.** That is the whole opt-in — there is no flag to enable it.
 
 ```dsl
 model
@@ -44,6 +44,19 @@ type document
 Declaring the type IS the opt-in because the feature is meaningless without a model that can express agent grants, and because of how OpenFGA fails: checking `agent:x` against a model with **no** `agent` type does not return `false`, it **errors** — and permission checks fail closed on errors. A flag that could be switched on against an unprepared model would deny every permission check for every delegated caller: a total authorization outage, not a graceful degradation. Auto-detection makes that state unreachable.
 
 Detection is cached per authorization-model id, so writing a new model version takes effect immediately. The model-id lookup itself still runs per delegated request; only the type enumeration is cached.
+
+:::info What happens before you declare the type (changed in 2.4.0)
+
+A delegated check against a model with **no** `type agent` is now **denied**.
+Before 2.4.0 it authorized as the delegating user alone, which silently dropped
+the agent half of the intersection.
+
+If that denial blocks you mid-migration,
+[`--fga-allow-unconstrained-agents`](../core/server-config#--fga-allow-unconstrained-agents)
+restores the old behaviour — with the agent carrying its user's full authority,
+logged and metered on every request. It is a migration aid, not a setting to
+leave on.
+:::
 
 :::note Before you declare the type
 The moment `type agent` appears in your model, every delegated caller must ALSO satisfy the agent half. Grant your agents before you deploy the model, or their calls start being denied. The [`denied_by_agent` metric](#observability) tells you exactly this is happening.


### PR DESCRIPTION
Closes the two flag-coverage gaps found by diffing the server's **134 CLI flags** against everything under `docs/`.

## Method

Extracted the authoritative flag list from `authorizer --help` on `main`, then set-differenced it against every `--flag` token in `docs/**/*.md`. Checked the whole docs tree, not just `server-config.md` — several flags are legitimately documented in `grpc.md` or `databases.md`, and counting only one page would have reported 28 false gaps.

Result before: **132/134**. After: **134/134**.

## `--app-cookie-same-site` — zero coverage in any form

Not documented anywhere, under any spelling (no `--app-cookie-same-site`, no `APP_COOKIE_SAME_SITE`, not even the word "SameSite"). That matters more than a normal gap because as of 2.4.0 an unrecognised value **exits at boot**.

Now documented with the accepted values, why the default is `none`, and the failure mode the validation exists to prevent: the old silent fallback meant an operator who asked for `strict` and mistyped it got `lax` — a real downgrade from what they requested, with nothing anywhere saying so.

Also records the one place that deliberately ignores the setting: the OAuth `state` cookie is always `Lax`/`None`, because a provider callback arrives cross-site (a cross-site `form_post` for Apple) and `Strict` withholds cookies on exactly those. Honouring `strict` there would break every social login on the deployment — worth stating so nobody "fixes" the inconsistency later.

## `--fga-allow-unconstrained-agents` — undocumented, and it changes an authorization outcome

Documented under the FGA section with an explicit warning: it restores the pre-2.4.0 behaviour where a delegated check against a model with no `type agent` authorizes as the delegating user alone, meaning **agents carry their user's full authority**. Notes that every such request is logged and metered as `not_enforced`, and that the real fix is adding `type agent`.

## One correction in `agent-identity.md`

That page said declaring the type is the whole opt-in — "there is no flag". Still true of the *opt-in*, so I did not delete it, just narrowed it to "no flag to enable it". But a flag now governs what happens **before** the type is declared, and the page said nothing about it, so a reader hitting the new denial mid-migration had no pointer. Added a note linking to the flag.

## Verified

- `npm run build` — exit 0, **zero broken-link warnings** (worth stating explicitly: this site sets `onBrokenLinks: 'warn'`, so a broken link would not fail the build)
- coverage diff re-run after the edits: **134/134, none missing**
