### PR TITLE
fix(docs): add mandatory flags missing from runnable examples

### DIFF
--- a/docs/core/mcp.md
+++ b/docs/core/mcp.md
@@ -273,6 +273,8 @@ authorizer mcp \
   --database-type=sqlite \
   --database-url=auth.db \
   --url=http://localhost:8080 \
+  --jwt-type=HS256 \
+  --jwt-secret=your-jwt-secret \
   --encryption-key=your-encryption-key \
   --mcp-bearer="$USER_ACCESS_TOKEN"
 ```
@@ -326,6 +328,8 @@ Most MCP hosts read a JSON config that declares the command to spawn. For
         "--client-id", "YOUR_CLIENT_ID",
         "--database-type", "sqlite",
         "--database-url", "auth.db",
+        "--jwt-type", "HS256",
+        "--jwt-secret", "your-jwt-secret",
         "--encryption-key", "your-encryption-key",
         "--url", "https://auth.example.com",
         "--mcp-bearer", "USER_ACCESS_TOKEN"

--- a/docs/core/rate-limiting.md
+++ b/docs/core/rate-limiting.md
@@ -144,6 +144,9 @@ services:
       - --database-url=postgres://user:pass@db:5432/authorizer
       - --url=https://auth.example.com
       - --encryption-key=your-encryption-key
+      - --jwt-type=HS256
+      - --jwt-secret=your-jwt-secret
+      - --admin-secret=your-admin-secret
       - --redis-url=redis://redis:6379
       - --rate-limit-rps=30
       - --rate-limit-burst=20

--- a/docs/core/sso-guide.md
+++ b/docs/core/sso-guide.md
@@ -64,7 +64,13 @@ authorizer \
   --smtp-username "auth@yourcompany.com" \
   --smtp-password "..." \
   --smtp-sender-email "auth@yourcompany.com" \
-  --encryption-key your-encryption-key
+  --jwt-type RS256 \
+  --jwt-private-key "$(cat jwt-private.pem)" \
+  --jwt-public-key "$(cat jwt-public.pem)" \
+  --encryption-key your-encryption-key \
+  --client-id YOUR_CLIENT_ID \
+  --client-secret YOUR_CLIENT_SECRET \
+  --admin-secret YOUR_ADMIN_SECRET
 ```
 
 Key flags for SSO:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -24,6 +24,32 @@ docker run -p 8080:8080 quay.io/authorizer/authorizer:latest \
   --client-secret=secret
 ```
 
+### Persisting data across restarts
+
+The command above writes `test.db` inside the container, so **every restart
+starts from an empty database**. Mount a named volume and put SQLite on it:
+
+```bash
+docker run -p 8080:8080 -u root \
+  -v authorizer_data:/authorizer/data \
+  quay.io/authorizer/authorizer \
+  --database-type=sqlite \
+  --database-url=/authorizer/data/data.db \
+  --url=http://localhost:8080 \
+  --client-id=123456 \
+  --client-secret=secret \
+  --admin-secret=admin \
+  --jwt-type=HS256 \
+  --jwt-secret=test \
+  --encryption-key=test-encryption-key
+```
+
+`-u root` is needed because the image runs as uid 1000 (`authorizer`), and a
+named volume mounted at a path the image does not already own is created
+root-owned — without it the process cannot create the database file. Drop it
+once you `chown` the volume, or use a managed database instead.
+
+
 Then open `http://localhost:8080/app` for the built-in login UI.
 
 ---

--- a/docs/integrations/hasura.md
+++ b/docs/integrations/hasura.md
@@ -28,7 +28,7 @@ You can also deploy Authorizer instance using
 
 > **Note:** If you are trying out with one click deployment options like railway then template is configured in a way that it will also deploy postgres + redis for you. For other deployment options, start the server with the required CLI flags:
 > ```bash
-> ./authorizer --database-type=sqlite --database-url=test.db --jwt-type=HS256 --jwt-secret=test --encryption-key=test-encryption-key --admin-secret=admin --client-id=123456 --client-secret=secret
+> ./authorizer --database-type=sqlite --database-url=test.db --url=http://localhost:8080 --jwt-type=HS256 --jwt-secret=test --encryption-key=test-encryption-key --admin-secret=admin --client-id=123456 --client-secret=secret
 > ```
 > You can also configure `--redis-url` to have persisted sessions. For more information check [Server Configuration](/core/server-config).
 


### PR DESCRIPTION
## Why

Three documented commands could not boot as written. Each fails on a flag the server now requires, before reaching the rest:

| Page | Missing | Fails with |
|---|---|---|
| `sso-guide` | `--jwt-*`, `--client-id/secret`, `--admin-secret` | `missing jwt type` |
| `rate-limiting` (compose) | `--jwt-*`, `--admin-secret` | `missing jwt type` |
| `mcp` (both bash and JSON forms) | `--jwt-*` | starts, then every tool call returns `Unauthenticated` |

The MCP one is the subtle case: `authorizer mcp` opens the database and validates the bearer **itself**, so it needs the same `--jwt-*` settings as the server that minted the token. Without them it starts fine and then fails every call, which reads as a permissions bug rather than missing config.

Verified the corrected `sso-guide` flag set boots against a build of `authorizer` `main` — it reaches the HTTP listener instead of exiting.

## Also: persisting data

The Docker quick start wrote SQLite **inside the container**, so every restart began from an empty database and nothing said so. Adds a named-volume variant, including why `-u root` is needed (the image runs as uid 1000, and a named volume mounted at a path it does not already own is created root-owned).

## Scope

Only blocks that actually start a server. Left alone: per-engine flag fragments in `databases.md`, the FGA store snippet in `authorization.md`, the v1 "before" examples, and the env-var mapping blocks that end in `...`.

`npm run build` clean, zero broken-link or anchor warnings.